### PR TITLE
Drop greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ notifications:
     on_failure: always
 before_install:
 - npm install -g npm
-- npm install -g greenkeeper-lockfile@1.14.0
-before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload
 script:
 - make validate-no-uncommitted-package-lock-changes
 - npm run lint


### PR DESCRIPTION
Since late 2018, greenkeeper handles lockfiles for public packages itself.

https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0

I've proposed a similar fix to the cookie cutter repo: https://github.com/edx/front-end-cookie-cutter-application/pull/156