### PR TITLE
Fix nested path URLs not finding webfonts

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.js', '.jsx'],

--- a/public/index.html
+++ b/public/index.html
@@ -4,11 +4,9 @@
       <title>Publisher Alpha | edX</title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <base href="/">
   </head>
   <body>
-    <head>
-      <base href="/" />
-    </head>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
The <base> change is not strictly required. I think firefox was able to determine what we were trying to say regardless. But figured this is more compliant.