### PR TITLE
Add CourseView route and view

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -99,6 +99,7 @@ module.exports = Merge.smart(commonConfig, {
       NODE_ENV: 'development',
       BASE_URL: 'localhost:18400',
       LMS_BASE_URL: 'http://localhost:18000',
+      DISCOVERY_API_BASE_URL: 'http://localhost:18381',
       LOGIN_URL: 'http://localhost:18000/login',
       LOGOUT_URL: 'http://localhost:18000/logout',
       CSRF_TOKEN_API_PATH: '/csrf/api/v1/token',

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -118,6 +118,7 @@ module.exports = Merge.smart(commonConfig, {
       NODE_ENV: 'production',
       BASE_URL: null,
       LMS_BASE_URL: null,
+      DISCOVERY_API_BASE_URL: null,
       LOGIN_URL: null,
       LOGOUT_URL: null,
       CSRF_TOKEN_API_PATH: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,6 +1110,15 @@
         "is-buffer": "1.1.6"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz",
+      "integrity": "sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -5713,26 +5722,6 @@
         "pend": "1.2.0"
       }
     },
-    "fetch-mock": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.0.tgz",
-      "integrity": "sha512-KxBeS8vsADFbWPVomuwxYqOJ2obZo6CidgkypjDPeu6zl+tAJvh2GfLDmJ8u//xgBGM9iOGwOxafeqAclilH2A==",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "glob-to-regexp": "0.4.0",
-        "path-to-regexp": "2.4.0",
-        "whatwg-url": "6.5.0"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-          "dev": true
-        }
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -6650,12 +6639,6 @@
       "requires": {
         "is-glob": "2.0.1"
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz",
-      "integrity": "sha512-fyPCII4vn9Gvjq2U/oDAfP433aiE64cyP/CJjRJcpVGjqqNdioUYn9+r0cSzT1XPwmGAHuTT7iv+rQT8u/YHKQ==",
-      "dev": true
     },
     "global-modules": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.16.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.1",
@@ -59,7 +60,6 @@
     "es-check": "^5.0.0",
     "eslint-config-edx": "^4.0.3",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
-    "fetch-mock": "^7.3.0",
     "file-loader": "^3.0.1",
     "gh-pages": "^2.0.1",
     "html-webpack-harddisk-plugin": "^1.0.1",

--- a/src/components/LabelledData/LabelledData.test.jsx
+++ b/src/components/LabelledData/LabelledData.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import LabelledData from './index';
+
+describe('LabelledData', () => {
+  it('accepts elements', () => {
+    const component = shallow(<LabelledData label={<i>Hello</i>} value={<b>Goodbye</b>} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('escapes html by default', () => {
+    const component = shallow(<LabelledData label="<i>1</i>" value="<b>2</b>" />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders html if asked', () => {
+    const component = shallow(<LabelledData label="<i>1</i>" value="<b>2</b>" html />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/LabelledData/__snapshots__/LabelledData.test.jsx.snap
+++ b/src/components/LabelledData/__snapshots__/LabelledData.test.jsx.snap
@@ -1,0 +1,501 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LabelledData accepts elements 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <LabelledData
+    html={false}
+    label={
+      <i>
+        Hello
+      </i>
+    }
+    value={
+      <b>
+        Goodbye
+      </b>
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="labelled-data-label col-2 font-weight-bold"
+        >
+          <i>
+            Hello
+          </i>
+          :
+        </div>,
+        false,
+        <div
+          className="labelled-data-value col"
+        >
+          <b>
+            Goodbye
+          </b>
+        </div>,
+      ],
+      "className": "row",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <i>
+              Hello
+            </i>,
+            ":",
+          ],
+          "className": "labelled-data-label col-2 font-weight-bold",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Hello",
+            },
+            "ref": null,
+            "rendered": "Hello",
+            "type": "i",
+          },
+          ":",
+        ],
+        "type": "div",
+      },
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <b>
+            Goodbye
+          </b>,
+          "className": "labelled-data-value col",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Goodbye",
+          },
+          "ref": null,
+          "rendered": "Goodbye",
+          "type": "b",
+        },
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="labelled-data-label col-2 font-weight-bold"
+          >
+            <i>
+              Hello
+            </i>
+            :
+          </div>,
+          false,
+          <div
+            className="labelled-data-value col"
+          >
+            <b>
+              Goodbye
+            </b>
+          </div>,
+        ],
+        "className": "row",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <i>
+                Hello
+              </i>,
+              ":",
+            ],
+            "className": "labelled-data-label col-2 font-weight-bold",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Hello",
+              },
+              "ref": null,
+              "rendered": "Hello",
+              "type": "i",
+            },
+            ":",
+          ],
+          "type": "div",
+        },
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <b>
+              Goodbye
+            </b>,
+            "className": "labelled-data-value col",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Goodbye",
+            },
+            "ref": null,
+            "rendered": "Goodbye",
+            "type": "b",
+          },
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`LabelledData escapes html by default 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <LabelledData
+    html={false}
+    label="<i>1</i>"
+    value="<b>2</b>"
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="labelled-data-label col-2 font-weight-bold"
+        >
+          &lt;i&gt;1&lt;/i&gt;
+          :
+        </div>,
+        false,
+        <div
+          className="labelled-data-value col"
+        >
+          &lt;b&gt;2&lt;/b&gt;
+        </div>,
+      ],
+      "className": "row",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "<i>1</i>",
+            ":",
+          ],
+          "className": "labelled-data-label col-2 font-weight-bold",
+        },
+        "ref": null,
+        "rendered": Array [
+          "<i>1</i>",
+          ":",
+        ],
+        "type": "div",
+      },
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "<b>2</b>",
+          "className": "labelled-data-value col",
+        },
+        "ref": null,
+        "rendered": "<b>2</b>",
+        "type": "div",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="labelled-data-label col-2 font-weight-bold"
+          >
+            &lt;i&gt;1&lt;/i&gt;
+            :
+          </div>,
+          false,
+          <div
+            className="labelled-data-value col"
+          >
+            &lt;b&gt;2&lt;/b&gt;
+          </div>,
+        ],
+        "className": "row",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "<i>1</i>",
+              ":",
+            ],
+            "className": "labelled-data-label col-2 font-weight-bold",
+          },
+          "ref": null,
+          "rendered": Array [
+            "<i>1</i>",
+            ":",
+          ],
+          "type": "div",
+        },
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "<b>2</b>",
+            "className": "labelled-data-value col",
+          },
+          "ref": null,
+          "rendered": "<b>2</b>",
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`LabelledData renders html if asked 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <LabelledData
+    html={true}
+    label="<i>1</i>"
+    value="<b>2</b>"
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <div
+          className="labelled-data-label col-2 font-weight-bold"
+        >
+          &lt;i&gt;1&lt;/i&gt;
+          :
+        </div>,
+        <div
+          className="labelled-data-value col"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<b>2</b>",
+            }
+          }
+        />,
+        false,
+      ],
+      "className": "row",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            "<i>1</i>",
+            ":",
+          ],
+          "className": "labelled-data-label col-2 font-weight-bold",
+        },
+        "ref": null,
+        "rendered": Array [
+          "<i>1</i>",
+          ":",
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "className": "labelled-data-value col",
+          "dangerouslySetInnerHTML": Object {
+            "__html": "<b>2</b>",
+          },
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "div",
+      },
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="labelled-data-label col-2 font-weight-bold"
+          >
+            &lt;i&gt;1&lt;/i&gt;
+            :
+          </div>,
+          <div
+            className="labelled-data-value col"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<b>2</b>",
+              }
+            }
+          />,
+          false,
+        ],
+        "className": "row",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "<i>1</i>",
+              ":",
+            ],
+            "className": "labelled-data-label col-2 font-weight-bold",
+          },
+          "ref": null,
+          "rendered": Array [
+            "<i>1</i>",
+            ":",
+          ],
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "className": "labelled-data-value col",
+            "dangerouslySetInnerHTML": Object {
+              "__html": "<b>2</b>",
+            },
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "div",
+        },
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/LabelledData/index.jsx
+++ b/src/components/LabelledData/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+const defaultProps = {
+  value: '',
+  html: false,
+};
+
+const inputProps = {
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  html: PropTypes.bool,
+};
+
+function LabelledData({ label, value, html }) {
+  return (
+    <div className="row">
+      <div className="labelled-data-label col-2 font-weight-bold">{label}:</div>
+      {html &&
+        <div
+          className="labelled-data-value col"
+          dangerouslySetInnerHTML={{ __html: value }} // eslint-disable-line react/no-danger
+        />
+      }
+      {!html && <div className="labelled-data-value col">{value}</div>}
+    </div>
+  );
+}
+
+LabelledData.defaultProps = defaultProps;
+LabelledData.propTypes = inputProps;
+
+export default LabelledData;

--- a/src/containers/CourseView/CourseView.test.jsx
+++ b/src/containers/CourseView/CourseView.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { CourseViewBasic as CourseView } from './index';
+
+describe('CourseView', () => {
+  it('shows spinner while loading', () => {
+    const component = shallow(<CourseView
+      courseInfo={{
+        error: null,
+        isFetching: true,
+        data: {},
+      }}
+    />);
+    expect(component.find('#spinner')).toHaveLength(1);
+  });
+
+  it('shows a fetch error', async () => {
+    const component = shallow(<CourseView
+      courseInfo={{
+        error: 'Failed.',
+        isFetching: true,
+        data: {},
+      }}
+    />);
+    expect(component.find('#error').getElement().props.dialog).toEqual('Failed.');
+  });
+
+  it('calls fetch', () => {
+    let called = false;
+    shallow(<CourseView fetchCourseInfo={() => { called = true; }} />);
+    expect(called).toBe(true);
+  });
+
+  describe('happy path', () => {
+    let component;
+
+    beforeAll(async () => {
+      const courseInfo = {
+        error: null,
+        isFetching: false,
+        data: {
+          additional_information: 'Add Info',
+          faq: 'FAQ',
+          full_description: 'Long Desc',
+          image: { src: 'https://example.com/image' },
+          key: 'edX+DemoX',
+          learner_testimonials: 'Learner Testimonial',
+          level_type: 'Intermediate',
+          outcome: 'Outcome',
+          prerequisites_raw: 'Needs classes',
+          short_description: 'Short Desc',
+          subjects: [
+            {
+              name: 'Primary',
+            },
+            {
+              name: 'Secondary',
+            },
+          ],
+          syllabus_raw: 'Hello World',
+          title: 'Dogs & You',
+          video: { src: 'https://example.com/video' },
+        },
+      };
+      component = shallow(<CourseView courseInfo={courseInfo} />);
+    });
+
+    it('parses course number from a course key', () => {
+      expect(component.find('#number').getElement().props.value).toEqual('DemoX');
+    });
+
+    function checkElement(id, value, html) {
+      expect(component.find(id).getElement().props.value).toEqual(value);
+      expect(component.find(id).getElement().props.html).toEqual(html);
+    }
+
+    it('renders all elements as html or not as appropriate', () => {
+      checkElement('#faq', 'FAQ', true);
+      checkElement('#info', 'Add Info', true);
+      checkElement('#ldesc', 'Long Desc', true);
+      checkElement('#level', 'Intermediate', false);
+      checkElement('#number', 'DemoX', false);
+      checkElement('#outcome', 'Outcome', true);
+      checkElement('#prereq', 'Needs classes', true);
+      checkElement('#sdesc', 'Short Desc', true);
+      checkElement('#subjects', 'Primary, Secondary', false);
+      checkElement('#syllabus', 'Hello World', true);
+      checkElement('#title', 'Dogs & You', false);
+
+      checkElement('#image', <img alt="" src="https://example.com/image" />, false);
+
+      const videoElement = component.find('#video').getElement();
+      const videoValueProps = videoElement.props.value.props;
+      expect(videoValueProps.content).toEqual('https://example.com/video');
+      expect(videoValueProps.destination).toEqual('https://example.com/video');
+      expect(videoElement.props.html).toEqual(false);
+    });
+  });
+
+  describe('empty path', () => {
+    let component;
+
+    beforeAll(async () => {
+      const courseInfo = {
+        error: null,
+        isFetching: false,
+        // These empty values are what Discovery will send us when they are unset
+        data: {
+          additional_information: '',
+          faq: '',
+          full_description: '',
+          image: null,
+          key: 'edX/DemoX', // old-style
+          learner_testimonials: '',
+          level_type: null,
+          outcome: '',
+          prerequisites_raw: '',
+          short_description: '',
+          subjects: [],
+          syllabus_raw: '',
+          title: '',
+          video: null,
+        },
+      };
+      component = shallow(<CourseView courseInfo={courseInfo} />);
+    });
+
+    it('parses course number from an old-style course key', () => {
+      expect(component.find('#number').getElement().props.value).toEqual('DemoX');
+    });
+
+    it('renders all elements as html or not as appropriate', () => {
+      // Just spot check a few elements. We mostly care about whether an exception happened.
+      expect(component.find('#faq').getElement().props.value).toEqual('');
+      expect(component.find('#image').getElement().props.value).toEqual(null);
+      expect(component.find('#info').getElement().props.value).toEqual('');
+      expect(component.find('#ldesc').getElement().props.value).toEqual('');
+      expect(component.find('#level').getElement().props.value).toEqual('');
+      expect(component.find('#syllabus').getElement().props.value).toEqual('');
+      expect(component.find('#video').getElement().props.value).toEqual(null);
+    });
+  });
+});

--- a/src/containers/CourseView/index.jsx
+++ b/src/containers/CourseView/index.jsx
@@ -1,0 +1,138 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Hyperlink, Icon, StatusAlert } from '@edx/paragon';
+
+import LabelledData from '../../components/LabelledData';
+
+import { fetchCourseInfo } from '../../data/actions/courseInfo';
+
+
+class CourseView extends React.Component {
+  static propTypes = {
+    courseInfo: PropTypes.shape({
+      data: PropTypes.shape(),
+      error: PropTypes.string,
+      isFetching: PropTypes.bool,
+    }),
+    fetchCourseInfo: PropTypes.func,
+  };
+
+  static defaultProps = {
+    courseInfo: {},
+    fetchCourseInfo: () => null,
+  };
+
+  componentDidMount() {
+    this.props.fetchCourseInfo();
+  }
+
+  render() {
+    if (!this.props.courseInfo) {
+      return null;
+    }
+
+    const {
+      data, error, isFetching,
+    } = this.props.courseInfo;
+
+    if (error) {
+      return (
+        <StatusAlert
+          id="error"
+          alertType="danger"
+          dismissible={false}
+          open
+          dialog={error}
+          className={['text-center', 'mx-auto', 'w-50']}
+        />
+      );
+    }
+
+    if (isFetching) {
+      return (
+        <div className="mx-auto text-center">
+          <Icon
+            id="spinner"
+            className={['fa', 'fa-circle-o-notch', 'fa-spin', 'fa-3x', 'fa-fw']}
+          />
+        </div>
+      );
+    }
+
+    if (!data || !data.key) {
+      return null;
+    }
+
+    const keyParts = data.key.split(/\+|\//);
+    const number = keyParts[keyParts.length - 1];
+    const subjects = data.subjects.map(x => x.name);
+
+    return (
+      <div className="container mx-auto">
+        <LabelledData id="title" label="Title" value={data.title} />
+        <LabelledData id="number" label="Number" value={number} />
+        <LabelledData id="sdesc" label="Short Description" value={data.short_description} html />
+        <LabelledData id="ldesc" label="Long Description" value={data.full_description} html />
+        <LabelledData id="outcome" label="What You Will Learn" value={data.outcome} html />
+        <LabelledData id="subjects" label="Subjects" value={subjects.join(', ')} />
+        <LabelledData
+          id="image"
+          label="Course Image"
+          value={
+            data.image && data.image.src &&
+            <img src={data.image.src} alt="" />
+          }
+        />
+        <LabelledData id="prereq" label="Prerequisites" value={data.prerequisites_raw} html />
+        <LabelledData id="level" label="Course Level" value={data.level_type || ''} />
+        <LabelledData
+          id="testimonials"
+          label="Learner Testimonials"
+          value={data.learner_testimonials}
+          html
+        />
+        <LabelledData id="faq" label="FAQ" value={data.faq} html />
+        <LabelledData
+          id="info"
+          label="Additional Information"
+          value={data.additional_information}
+          html
+        />
+        <LabelledData id="syllabus" label="Syllabus" value={data.syllabus_raw} html />
+        <LabelledData
+          id="video"
+          label="About Video Link"
+          value={
+            data.video && data.video.src &&
+            <Hyperlink content={data.video.src} destination={data.video.src} target="_blank" />
+          }
+        />
+      </div>
+    );
+  }
+}
+
+export { CourseView as CourseViewBasic }; // used in tests
+
+
+// *** Redux routing ***
+
+const mapStateToProps = state => ({
+  courseInfo: state.courseInfo,
+});
+
+const mapDispatchToProps = {
+  fetchCourseInfo,
+};
+
+const mergeProps = (stateProps, actionProps, { id }) => ({
+  ...stateProps,
+  fetchCourseInfo: () => actionProps.fetchCourseInfo(id),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+)(CourseView);

--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -1,0 +1,52 @@
+import {
+  FAIL_COURSE_INFO,
+  RECEIVE_COURSE_INFO,
+  REQUEST_COURSE_INFO,
+  UUID_REGEX,
+} from '../constants/courseInfo';
+
+import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
+
+
+export function failCourseInfo(id, error) {
+  return { type: FAIL_COURSE_INFO, id, error };
+}
+
+export function receiveCourseInfo(id, data) {
+  return { type: RECEIVE_COURSE_INFO, id, data };
+}
+
+export function requestCourseInfo(id) {
+  return { type: REQUEST_COURSE_INFO, id };
+}
+
+export function fetchCourseInfo(id) {
+  return (dispatch) => {
+    // We only support UUIDs right now, not course keys
+    if (!UUID_REGEX.test(id)) {
+      const error = `Could not get course information. ${id} is not a valid course UUID.`;
+      dispatch(failCourseInfo(id, error));
+      return Promise.resolve(); // early exit with empty promise
+    }
+
+    dispatch(requestCourseInfo(id));
+
+    return DiscoveryDataApiService.fetchCourse(id)
+      .then((response) => {
+        const course = response.data;
+
+        // Confirm it looks vaguely correct
+        if (!course || !('key' in course)) {
+          throw Error('Did not understand response.');
+        }
+
+        dispatch(receiveCourseInfo(id, course));
+      })
+      .catch((error) => {
+        dispatch(failCourseInfo(
+          id,
+          `Could not get course information. ${error.toString()}`,
+        ));
+      });
+  };
+}

--- a/src/data/actions/courseInfo.test.js
+++ b/src/data/actions/courseInfo.test.js
@@ -1,0 +1,90 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import MockAdapter from 'axios-mock-adapter';
+import apiClient from '../apiClient';
+
+import {
+  failCourseInfo,
+  fetchCourseInfo,
+  receiveCourseInfo,
+  requestCourseInfo,
+} from './courseInfo';
+
+const mockStore = configureMockStore([thunk]);
+const mockClient = new MockAdapter(apiClient);
+
+const uuid = '11111111-1111-1111-1111-111111111111';
+
+
+describe('courseInfo actions', () => {
+  afterEach(() => {
+    mockClient.reset();
+  });
+
+  it('handles fetch success', () => {
+    mockClient.onGet(`http://localhost:18381/api/v1/courses/${uuid}/`)
+      .replyOnce(200, JSON.stringify({
+        key: 'DemoX+TestCourse',
+      }));
+
+    const expectedActions = [
+      requestCourseInfo(uuid),
+      receiveCourseInfo(uuid, { key: 'DemoX+TestCourse' }),
+    ];
+    const store = mockStore();
+
+    return store.dispatch(fetchCourseInfo(uuid)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('handles fetch error code', () => {
+    mockClient.onGet(`http://localhost:18381/api/v1/courses/${uuid}/`)
+      .replyOnce(500, '');
+
+    const expectedActions = [
+      requestCourseInfo(uuid),
+      failCourseInfo(
+        uuid,
+        'Could not get course information. Error: Request failed with status code 500',
+      ),
+    ];
+    const store = mockStore();
+
+    return store.dispatch(fetchCourseInfo(uuid)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('handles fetch with bad id', () => {
+    const expectedActions = [
+      failCourseInfo(
+        'test',
+        'Could not get course information. test is not a valid course UUID.',
+      ),
+    ];
+    const store = mockStore();
+
+    return store.dispatch(fetchCourseInfo('test')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+
+  it('handles fetch with bad data', () => {
+    mockClient.onGet(`http://localhost:18381/api/v1/courses/${uuid}/`)
+      .replyOnce(200, {});
+
+    const expectedActions = [
+      requestCourseInfo(uuid),
+      failCourseInfo(
+        uuid,
+        'Could not get course information. Error: Did not understand response.',
+      ),
+    ];
+    const store = mockStore();
+
+    return store.dispatch(fetchCourseInfo(uuid)).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/data/constants/courseInfo.js
+++ b/src/data/constants/courseInfo.js
@@ -1,0 +1,5 @@
+export const FAIL_COURSE_INFO = 'FAIL_COURSE_INFO';
+export const RECEIVE_COURSE_INFO = 'RECEIVE_COURSE_INFO';
+export const REQUEST_COURSE_INFO = 'REQUEST_COURSE_INFO';
+
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;

--- a/src/data/reducers/courseInfo.js
+++ b/src/data/reducers/courseInfo.js
@@ -1,0 +1,39 @@
+import {
+  FAIL_COURSE_INFO,
+  RECEIVE_COURSE_INFO,
+  REQUEST_COURSE_INFO,
+} from '../constants/courseInfo';
+
+
+const initialState = {
+  data: {},
+  isFetching: false,
+  error: null,
+};
+
+function courseInfo(state = initialState, action) {
+  switch (action.type) {
+    case FAIL_COURSE_INFO:
+      return Object.assign({}, state, {
+        data: {},
+        isFetching: false,
+        error: action.error,
+      });
+    case RECEIVE_COURSE_INFO:
+      return Object.assign({}, state, {
+        data: action.data,
+        isFetching: false,
+        error: null,
+      });
+    case REQUEST_COURSE_INFO:
+      return Object.assign({}, state, {
+        data: {},
+        isFetching: true,
+        error: null,
+      });
+    default:
+      return state;
+  }
+}
+
+export default courseInfo;

--- a/src/data/reducers/courseInfo.test.js
+++ b/src/data/reducers/courseInfo.test.js
@@ -1,0 +1,51 @@
+import {
+  failCourseInfo,
+  receiveCourseInfo,
+  requestCourseInfo,
+} from '../actions/courseInfo';
+
+import courseInfo from './courseInfo';
+
+
+describe('courseInfo reducer', () => {
+  const oldState = { // overwritten as old state for actions
+    data: { nope: 'bad data' },
+    isFetching: true,
+    error: 'error occurred',
+  };
+
+  it('initial state is valid', () => {
+    expect(courseInfo(undefined, {})).toEqual({
+      data: {},
+      isFetching: false,
+      error: null,
+    });
+  });
+
+  it('request works', () => {
+    expect(courseInfo(oldState, requestCourseInfo('test')))
+      .toEqual({
+        data: {},
+        isFetching: true,
+        error: null,
+      });
+  });
+
+  it('receive works', () => {
+    expect(courseInfo(oldState, receiveCourseInfo('test', { key: 'DemoX+TestCourse' })))
+      .toEqual({
+        data: { key: 'DemoX+TestCourse' },
+        isFetching: false,
+        error: null,
+      });
+  });
+
+  it('fail works', () => {
+    expect(courseInfo(oldState, failCourseInfo('test', 'failure')))
+      .toEqual({
+        data: {},
+        isFetching: false,
+        error: 'failure',
+      });
+  });
+});

--- a/src/data/reducers/index.js
+++ b/src/data/reducers/index.js
@@ -2,6 +2,8 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 import { reducer as formReducer } from 'redux-form';
 
+import courseInfo from './courseInfo';
+
 const identityReducer = (state) => {
   const newState = { ...state };
   return newState;
@@ -12,5 +14,6 @@ export default history => combineReducers({
   // The authentication state is added as initialState when
   // creating the store in data/store.js.
   authentication: identityReducer,
+  courseInfo,
   form: formReducer,
 });

--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -1,0 +1,12 @@
+import apiClient from '../apiClient';
+
+class DiscoveryDataApiService {
+  static discoveryBaseUrl = `${process.env.DISCOVERY_API_BASE_URL}/api/v1`;
+
+  static fetchCourse(uuid) {
+    const url = `${DiscoveryDataApiService.discoveryBaseUrl}/courses/${uuid}/`;
+    return apiClient.get(url);
+  }
+}
+
+export default DiscoveryDataApiService;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,7 @@ import './App.scss';
 import CourseDashboard from './containers/CourseDashboard';
 
 import apiClient from './data/apiClient';
+import CourseView from './containers/CourseView';
 
 const App = () => (
   <Provider store={store}>
@@ -25,7 +26,17 @@ const App = () => (
           <Switch>
             <PrivateRoute
               path="/"
+              exact
               component={CourseDashboard}
+              authenticatedAPIClient={apiClient}
+              redirect={`${process.env.BASE_URL}`}
+            />
+            <PrivateRoute
+              path="/courses/:id"
+              exact
+              render={({ match }) => (
+                <CourseView id={match.params.id} />
+              )}
               authenticatedAPIClient={apiClient}
               redirect={`${process.env.BASE_URL}`}
             />

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -4,3 +4,7 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+// These configuration values are usually set in webpack's EnvironmentPlugin however
+// Jest does not use webpack so we need to set these so for testing
+process.env.DISCOVERY_API_BASE_URL = 'http://localhost:18381';


### PR DESCRIPTION
This adds a simple read-only view of a given course.

Adds courses/<uuid> route.

It looks like crap right now. But that can be fixed up later.

Normal view:
![screenshot_2019-01-23 publisher alpha edx](https://user-images.githubusercontent.com/1196901/51641398-08541780-1f34-11e9-9530-6b64e92c5b8e.png)

Error screen:
![screenshot_2019-01-23 publisher alpha edx 1](https://user-images.githubusercontent.com/1196901/51641407-0be79e80-1f34-11e9-9540-967a87088698.png)

Spinner while data loads:
![screenshot_2019-01-23 publisher alpha edx 2](https://user-images.githubusercontent.com/1196901/51641410-0e49f880-1f34-11e9-9f87-6f4bd8a3bad1.png)