### PR TITLE
Ask for editable versions whenever we query courses

### DIFF
--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -4,8 +4,13 @@ class DiscoveryDataApiService {
   static discoveryBaseUrl = `${process.env.DISCOVERY_API_BASE_URL}/api/v1`;
 
   static fetchCourse(uuid) {
+    const queryParams = {
+      editable: 1,
+    };
     const url = `${DiscoveryDataApiService.discoveryBaseUrl}/courses/${uuid}/`;
-    return apiClient.get(url);
+    return apiClient.get(url, {
+      params: queryParams,
+    });
   }
 
   static fetchCourses(options) {
@@ -46,8 +51,13 @@ class DiscoveryDataApiService {
   }
 
   static fetchCourseOptions(uuid) {
+    const queryParams = {
+      editable: 1,
+    };
     const url = `${DiscoveryDataApiService.discoveryBaseUrl}/courses/${uuid}/`;
-    return apiClient.options(url);
+    return apiClient.options(url, {
+      params: queryParams,
+    });
   }
 
   static editCourse(courseData) {


### PR DESCRIPTION
This will ensure that we get the draft data back, if available. And will confirm that editor permissions are respected. It also protects against 404s if no non-draft version exists.