### PR TITLE
Fixing the issue where saving would result in a white page being disp…

### DIFF
--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -156,7 +156,7 @@ function editCourse(courseData, courseRunData) {
     // Send edit course PATCH
     return DiscoveryDataApiService.editCourse(courseData, courseRunData)
       .then((response) => {
-        const course = response.data;
+        const course = response[response.length - 1].data;
         dispatch(editCourseSuccess(course));
       })
       .catch((error) => {


### PR DESCRIPTION
…layed. This was caused because instead of only returning a single promise with the course data, we return an array with the course run data followed by the course data.