### PR TITLE
We recognize runs based on their key and not their uuid. This fix wil…

### DIFF
--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -44,7 +44,7 @@ class EditCoursePage extends React.Component {
     const { targetRun } = this.state;
     if (targetRun) {
       // If a course run triggered the submission, mark it as not a draft
-      const submittedRun = courseRuns.find(run => run.uuid === targetRun.uuid);
+      const submittedRun = courseRuns.find(run => run.key === targetRun.key);
       submittedRun.draft = false;
     }
     /* eslint-enable no-param-reassign */


### PR DESCRIPTION
…l make submit for draft apply to the correct run