### PR TITLE
Change the external wording from 'Live' to 'Published'. We are mainta…

### DIFF
--- a/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
@@ -605,7 +605,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="create-error"
@@ -673,7 +673,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -716,7 +716,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -758,7 +758,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-error",
@@ -819,7 +819,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -887,7 +887,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -930,7 +930,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-error"
@@ -972,7 +972,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-error",
@@ -1862,7 +1862,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -1881,7 +1881,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",
@@ -1981,7 +1981,7 @@ ShallowWrapper {
         >
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             id="user-info-error"
@@ -2048,7 +2048,7 @@ ShallowWrapper {
             false,
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="user-info-error"
@@ -2089,7 +2089,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "alertType": "danger",
-              "className": Array [],
+              "className": "",
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "user-info-error",
@@ -2185,7 +2185,7 @@ ShallowWrapper {
           >
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="user-info-error"
@@ -2252,7 +2252,7 @@ ShallowWrapper {
               false,
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="user-info-error"
@@ -2293,7 +2293,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "alertType": "danger",
-                "className": Array [],
+                "className": "",
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "user-info-error",

--- a/src/components/CreateCourseRunPage/CreateCourseRunForm.test.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunForm.test.jsx
@@ -13,11 +13,11 @@ describe('CreateCourseRunForm', () => {
       title="Test Course"
       uuid="00000000-0000-0000-0000-000000000001"
       pristine
-      submitting={false}
+      isCreating={false}
     />);
     expect(component).toMatchSnapshot();
   });
-  it('renders html correctly when submitting and creating', () => {
+  it('renders html correctly when creating', () => {
     const component = shallow(<BaseCreateCourseRunForm
       handleSubmit={() => {}}
       initialValues={{
@@ -26,7 +26,7 @@ describe('CreateCourseRunForm', () => {
       title="Test Course"
       uuid="00000000-0000-0000-0000-000000000001"
       pristine={false}
-      submitting
+      isCreating
     />);
     expect(component).toMatchSnapshot();
   });

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunForm.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunForm.test.jsx.snap
@@ -10,8 +10,8 @@ ShallowWrapper {
         "course": "edx+test101",
       }
     }
+    isCreating={false}
     pristine={true}
-    submitting={false}
     title="Test Course"
     uuid="00000000-0000-0000-0000-000000000001"
   />,
@@ -90,6 +90,7 @@ ShallowWrapper {
             >
               <button
                 className="btn btn-outline-primary"
+                disabled={false}
               >
                 Cancel
               </button>
@@ -218,6 +219,7 @@ ShallowWrapper {
               >
                 <button
                   className="btn btn-outline-primary"
+                  disabled={false}
                 >
                   Cancel
                 </button>
@@ -291,6 +293,7 @@ ShallowWrapper {
                 >
                   <button
                     className="btn btn-outline-primary"
+                    disabled={false}
                   >
                     Cancel
                   </button>
@@ -318,6 +321,7 @@ ShallowWrapper {
                 "props": Object {
                   "children": <button
                     className="btn btn-outline-primary"
+                    disabled={false}
                   >
                     Cancel
                   </button>,
@@ -332,7 +336,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": "Cancel",
                     "className": "btn btn-outline-primary",
-                    "disabled": undefined,
+                    "disabled": false,
                   },
                   "ref": null,
                   "rendered": "Cancel",
@@ -433,6 +437,7 @@ ShallowWrapper {
               >
                 <button
                   className="btn btn-outline-primary"
+                  disabled={false}
                 >
                   Cancel
                 </button>
@@ -561,6 +566,7 @@ ShallowWrapper {
                 >
                   <button
                     className="btn btn-outline-primary"
+                    disabled={false}
                   >
                     Cancel
                   </button>
@@ -634,6 +640,7 @@ ShallowWrapper {
                   >
                     <button
                       className="btn btn-outline-primary"
+                      disabled={false}
                     >
                       Cancel
                     </button>
@@ -661,6 +668,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <button
                       className="btn btn-outline-primary"
+                      disabled={false}
                     >
                       Cancel
                     </button>,
@@ -675,7 +683,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": "Cancel",
                       "className": "btn btn-outline-primary",
-                      "disabled": undefined,
+                      "disabled": false,
                     },
                     "ref": null,
                     "rendered": "Cancel",
@@ -736,7 +744,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`CreateCourseRunForm renders html correctly when submitting and creating 1`] = `
+exports[`CreateCourseRunForm renders html correctly when creating 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BaseCreateCourseRunForm
@@ -746,8 +754,8 @@ ShallowWrapper {
         "course": "edx+test101",
       }
     }
+    isCreating={true}
     pristine={false}
-    submitting={true}
     title="Test Course"
     uuid="00000000-0000-0000-0000-000000000001"
   />,
@@ -826,6 +834,7 @@ ShallowWrapper {
             >
               <button
                 className="btn btn-outline-primary"
+                disabled={true}
               >
                 Cancel
               </button>
@@ -839,7 +848,7 @@ ShallowWrapper {
                   "pending": "Creating",
                 }
               }
-              state="default"
+              state="pending"
             />
           </ButtonToolbar>
         </form>,
@@ -954,6 +963,7 @@ ShallowWrapper {
               >
                 <button
                   className="btn btn-outline-primary"
+                  disabled={true}
                 >
                   Cancel
                 </button>
@@ -967,7 +977,7 @@ ShallowWrapper {
                     "pending": "Creating",
                   }
                 }
-                state="default"
+                state="pending"
               />
             </ButtonToolbar>,
           ],
@@ -1027,6 +1037,7 @@ ShallowWrapper {
                 >
                   <button
                     className="btn btn-outline-primary"
+                    disabled={true}
                   >
                     Cancel
                   </button>
@@ -1040,7 +1051,7 @@ ShallowWrapper {
                       "pending": "Creating",
                     }
                   }
-                  state="default"
+                  state="pending"
                 />,
               ],
               "className": "",
@@ -1054,6 +1065,7 @@ ShallowWrapper {
                 "props": Object {
                   "children": <button
                     className="btn btn-outline-primary"
+                    disabled={true}
                   >
                     Cancel
                   </button>,
@@ -1068,7 +1080,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": "Cancel",
                     "className": "btn btn-outline-primary",
-                    "disabled": undefined,
+                    "disabled": true,
                   },
                   "ref": null,
                   "rendered": "Cancel",
@@ -1087,7 +1099,7 @@ ShallowWrapper {
                     "default": "Create",
                     "pending": "Creating",
                   },
-                  "state": "default",
+                  "state": "pending",
                 },
                 "ref": null,
                 "rendered": null,
@@ -1169,6 +1181,7 @@ ShallowWrapper {
               >
                 <button
                   className="btn btn-outline-primary"
+                  disabled={true}
                 >
                   Cancel
                 </button>
@@ -1182,7 +1195,7 @@ ShallowWrapper {
                     "pending": "Creating",
                   }
                 }
-                state="default"
+                state="pending"
               />
             </ButtonToolbar>
           </form>,
@@ -1297,6 +1310,7 @@ ShallowWrapper {
                 >
                   <button
                     className="btn btn-outline-primary"
+                    disabled={true}
                   >
                     Cancel
                   </button>
@@ -1310,7 +1324,7 @@ ShallowWrapper {
                       "pending": "Creating",
                     }
                   }
-                  state="default"
+                  state="pending"
                 />
               </ButtonToolbar>,
             ],
@@ -1370,6 +1384,7 @@ ShallowWrapper {
                   >
                     <button
                       className="btn btn-outline-primary"
+                      disabled={true}
                     >
                       Cancel
                     </button>
@@ -1383,7 +1398,7 @@ ShallowWrapper {
                         "pending": "Creating",
                       }
                     }
-                    state="default"
+                    state="pending"
                   />,
                 ],
                 "className": "",
@@ -1397,6 +1412,7 @@ ShallowWrapper {
                   "props": Object {
                     "children": <button
                       className="btn btn-outline-primary"
+                      disabled={true}
                     >
                       Cancel
                     </button>,
@@ -1411,7 +1427,7 @@ ShallowWrapper {
                     "props": Object {
                       "children": "Cancel",
                       "className": "btn btn-outline-primary",
-                      "disabled": undefined,
+                      "disabled": true,
                     },
                     "ref": null,
                     "rendered": "Cancel",
@@ -1430,7 +1446,7 @@ ShallowWrapper {
                       "default": "Create",
                       "pending": "Creating",
                     },
-                    "state": "default",
+                    "state": "pending",
                   },
                   "ref": null,
                   "rendered": null,

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -581,7 +581,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="create-error"
@@ -624,7 +624,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -654,7 +654,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -686,7 +686,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-error",
@@ -733,7 +733,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
@@ -776,7 +776,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
@@ -806,7 +806,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-error"
@@ -838,7 +838,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-error",

--- a/src/components/EditCoursePage/CollapsibleCourseRunFields.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRunFields.jsx
@@ -105,7 +105,7 @@ export const BaseCollapsibleCourseRunFields = ({
           component={RenderInputTextField}
           format={value => getDateString(value)}
           normalize={value => moment(value).toISOString()}
-          label={<FieldLabel text="Go Live date" />}
+          label={<FieldLabel text="Publish date" />}
           placeholder="mm/dd/yyyy"
           disabled={courseInReview}
         />

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRunFields.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRunFields.test.jsx.snap
@@ -140,7 +140,7 @@ ShallowWrapper {
                 className=""
                 required={false}
                 requiredForSubmit={false}
-                text="Go Live date"
+                text="Publish date"
               />
             }
             name="[object Object].go_live_date"
@@ -334,7 +334,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />
               }
               name="[object Object].go_live_date"
@@ -565,7 +565,7 @@ ShallowWrapper {
                 className=""
                 required={false}
                 requiredForSubmit={false}
-                text="Go Live date"
+                text="Publish date"
               />,
               "name": "[object Object].go_live_date",
               "normalize": [Function],
@@ -874,7 +874,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />
               }
               name="[object Object].go_live_date"
@@ -1068,7 +1068,7 @@ ShallowWrapper {
                     className=""
                     required={false}
                     requiredForSubmit={false}
-                    text="Go Live date"
+                    text="Publish date"
                   />
                 }
                 name="[object Object].go_live_date"
@@ -1299,7 +1299,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />,
                 "name": "[object Object].go_live_date",
                 "normalize": [Function],
@@ -1693,7 +1693,7 @@ ShallowWrapper {
                 className=""
                 required={false}
                 requiredForSubmit={false}
-                text="Go Live date"
+                text="Publish date"
               />
             }
             name="[object Object].go_live_date"
@@ -1887,7 +1887,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />
               }
               name="[object Object].go_live_date"
@@ -2118,7 +2118,7 @@ ShallowWrapper {
                 className=""
                 required={false}
                 requiredForSubmit={false}
-                text="Go Live date"
+                text="Publish date"
               />,
               "name": "[object Object].go_live_date",
               "normalize": [Function],
@@ -2427,7 +2427,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />
               }
               name="[object Object].go_live_date"
@@ -2621,7 +2621,7 @@ ShallowWrapper {
                     className=""
                     required={false}
                     requiredForSubmit={false}
-                    text="Go Live date"
+                    text="Publish date"
                   />
                 }
                 name="[object Object].go_live_date"
@@ -2852,7 +2852,7 @@ ShallowWrapper {
                   className=""
                   required={false}
                   requiredForSubmit={false}
-                  text="Go Live date"
+                  text="Publish date"
                 />,
                 "name": "[object Object].go_live_date",
                 "normalize": [Function],

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -3434,7 +3434,7 @@ ShallowWrapper {
         >
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             id="error"
@@ -3482,7 +3482,7 @@ ShallowWrapper {
             false,
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -3504,7 +3504,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "alertType": "danger",
-              "className": Array [],
+              "className": "",
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
@@ -3543,7 +3543,7 @@ ShallowWrapper {
           >
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -3591,7 +3591,7 @@ ShallowWrapper {
               false,
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
@@ -3613,7 +3613,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "alertType": "danger",
-                "className": Array [],
+                "className": "",
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
@@ -3718,7 +3718,7 @@ ShallowWrapper {
         >
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             id="error"
@@ -3766,7 +3766,7 @@ ShallowWrapper {
             false,
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -3788,7 +3788,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "alertType": "danger",
-              "className": Array [],
+              "className": "",
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
@@ -3827,7 +3827,7 @@ ShallowWrapper {
           >
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -3875,7 +3875,7 @@ ShallowWrapper {
               false,
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
@@ -3897,7 +3897,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "alertType": "danger",
-                "className": Array [],
+                "className": "",
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
@@ -4993,7 +4993,7 @@ ShallowWrapper {
         >
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             id="error"
@@ -5041,7 +5041,7 @@ ShallowWrapper {
             false,
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -5063,7 +5063,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "alertType": "danger",
-              "className": Array [],
+              "className": "",
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
@@ -5102,7 +5102,7 @@ ShallowWrapper {
           >
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -5150,7 +5150,7 @@ ShallowWrapper {
               false,
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
@@ -5172,7 +5172,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "alertType": "danger",
-                "className": Array [],
+                "className": "",
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
@@ -6223,7 +6223,7 @@ ShallowWrapper {
         >
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             id="error"
@@ -6271,7 +6271,7 @@ ShallowWrapper {
             false,
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -6293,7 +6293,7 @@ ShallowWrapper {
             "nodeType": "function",
             "props": Object {
               "alertType": "danger",
-              "className": Array [],
+              "className": "",
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
@@ -6332,7 +6332,7 @@ ShallowWrapper {
           >
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="error"
@@ -6380,7 +6380,7 @@ ShallowWrapper {
               false,
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
@@ -6402,7 +6402,7 @@ ShallowWrapper {
               "nodeType": "function",
               "props": Object {
                 "alertType": "danger",
-                "className": Array [],
+                "className": "",
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
@@ -6475,7 +6475,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -6494,7 +6494,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",
@@ -6565,7 +6565,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -6584,7 +6584,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",
@@ -6655,7 +6655,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -6674,7 +6674,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",

--- a/src/components/Pill/__snapshots__/Pill.test.jsx.snap
+++ b/src/components/Pill/__snapshots__/Pill.test.jsx.snap
@@ -218,11 +218,11 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "host",
       "props": Object {
-        "children": "Live",
+        "children": "Published",
         "className": "ml-2 badge badge-success",
       },
       "ref": null,
-      "rendered": "Live",
+      "rendered": "Published",
       "type": "span",
     },
   ],

--- a/src/components/Pill/index.jsx
+++ b/src/components/Pill/index.jsx
@@ -31,7 +31,7 @@ const Pill = ({ statuses }) => {
         break;
       case 'published':
         pills.push({
-          text: 'Live',
+          text: 'Published',
           className: 'badge badge-success',
         });
         break;

--- a/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
+++ b/src/components/RenderInputTextField/__snapshots__/RenderInputTextField.test.jsx.snap
@@ -7,6 +7,7 @@ ShallowWrapper {
     disabled={false}
     isValid={true}
     label="TestLabel"
+    name="Test"
     required={false}
     themes={
       Array [
@@ -42,6 +43,7 @@ ShallowWrapper {
       "inputRef": undefined,
       "isValid": true,
       "label": "TestLabel",
+      "name": "Test",
       "onBlur": [Function],
       "onChange": [Function],
       "onKeyPress": [Function],
@@ -76,6 +78,7 @@ ShallowWrapper {
         "inputRef": undefined,
         "isValid": true,
         "label": "TestLabel",
+        "name": "Test",
         "onBlur": [Function],
         "onChange": [Function],
         "onKeyPress": [Function],
@@ -128,6 +131,7 @@ ShallowWrapper {
     disabled={false}
     isValid={true}
     label="TestLabel"
+    name="Test"
     required={false}
     themes={
       Array [
@@ -163,6 +167,7 @@ ShallowWrapper {
       "inputRef": undefined,
       "isValid": true,
       "label": "TestLabel",
+      "name": "Test",
       "onBlur": [Function],
       "onChange": [Function],
       "onKeyPress": [Function],
@@ -197,6 +202,7 @@ ShallowWrapper {
         "inputRef": undefined,
         "isValid": true,
         "label": "TestLabel",
+        "name": "Test",
         "onBlur": [Function],
         "onChange": [Function],
         "onKeyPress": [Function],

--- a/src/components/RenderInputTextField/index.jsx
+++ b/src/components/RenderInputTextField/index.jsx
@@ -4,6 +4,7 @@ import { InputText } from '@edx/paragon';
 
 const RenderInputTextField = ({
   input,
+  name,
   label,
   type,
   disabled,
@@ -12,6 +13,7 @@ const RenderInputTextField = ({
 }) => (
   <InputText
     {...input}
+    name={name}
     label={label}
     type={type}
     disabled={disabled}
@@ -23,12 +25,14 @@ const RenderInputTextField = ({
 );
 
 RenderInputTextField.defaultProps = {
+  name: '',
   disabled: false,
   required: false,
 };
 
 RenderInputTextField.propTypes = {
   input: PropTypes.shape({}).isRequired,
+  name: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   type: PropTypes.string.isRequired,
   meta: PropTypes.shape({

--- a/src/components/RenderSelectField/__snapshots__/RenderSelectField.test.jsx.snap
+++ b/src/components/RenderSelectField/__snapshots__/RenderSelectField.test.jsx.snap
@@ -7,6 +7,7 @@ ShallowWrapper {
     disabled={false}
     isValid={true}
     label="TestLabel"
+    name="Test"
     options={
       Array [
         "one",
@@ -48,6 +49,7 @@ ShallowWrapper {
       "inputRef": undefined,
       "isValid": true,
       "label": "TestLabel",
+      "name": "Test",
       "onBlur": [Function],
       "onChange": [Function],
       "onKeyPress": [Function],
@@ -87,6 +89,7 @@ ShallowWrapper {
         "inputRef": undefined,
         "isValid": true,
         "label": "TestLabel",
+        "name": "Test",
         "onBlur": [Function],
         "onChange": [Function],
         "onKeyPress": [Function],

--- a/src/components/RenderSelectField/index.jsx
+++ b/src/components/RenderSelectField/index.jsx
@@ -4,6 +4,7 @@ import { InputSelect } from '@edx/paragon';
 
 const RenderSelectField = ({
   input,
+  name,
   label,
   disabled,
   required,
@@ -12,6 +13,7 @@ const RenderSelectField = ({
 }) => (
   <InputSelect
     {...input}
+    name={name}
     label={label}
     disabled={disabled}
     required={required}
@@ -23,12 +25,14 @@ const RenderSelectField = ({
 );
 
 RenderSelectField.defaultProps = {
+  name: '',
   disabled: false,
   required: false,
 };
 
 RenderSelectField.propTypes = {
   input: PropTypes.shape({}).isRequired,
+  name: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   meta: PropTypes.shape({
     touched: PropTypes.bool,

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -44,7 +44,7 @@ ShallowWrapper {
         </div>,
         <StatusAlert
           alertType="danger"
-          className={Array []}
+          className=""
           dismissible={false}
           iconClassNames={Array []}
           message="Required"
@@ -100,7 +100,7 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "alertType": "danger",
-          "className": Array [],
+          "className": "",
           "dismissible": false,
           "iconClassNames": Array [],
           "message": "Required",
@@ -199,7 +199,7 @@ ShallowWrapper {
           </div>,
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={Array []}
             message="Required"
@@ -255,7 +255,7 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "alertType": "danger",
-            "className": Array [],
+            "className": "",
             "dismissible": false,
             "iconClassNames": Array [],
             "message": "Required",

--- a/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
@@ -461,7 +461,7 @@ ShallowWrapper {
             </h2>
             <StatusAlert
               alertType="info"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="sent-from-edit-course-info"
@@ -531,7 +531,7 @@ ShallowWrapper {
               </h2>
               <StatusAlert
                 alertType="info"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="sent-from-edit-course-info"
@@ -576,7 +576,7 @@ ShallowWrapper {
                 </h2>,
                 <StatusAlert
                   alertType="info"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="sent-from-edit-course-info"
@@ -623,7 +623,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "info",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "sent-from-edit-course-info",
@@ -703,7 +703,7 @@ ShallowWrapper {
               </h2>
               <StatusAlert
                 alertType="info"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="sent-from-edit-course-info"
@@ -773,7 +773,7 @@ ShallowWrapper {
                 </h2>
                 <StatusAlert
                   alertType="info"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="sent-from-edit-course-info"
@@ -818,7 +818,7 @@ ShallowWrapper {
                   </h2>,
                   <StatusAlert
                     alertType="info"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="sent-from-edit-course-info"
@@ -865,7 +865,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "info",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "sent-from-edit-course-info",
@@ -1721,7 +1721,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -1740,7 +1740,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",
@@ -1812,7 +1812,7 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "alertType": "danger",
-      "className": Array [],
+      "className": "",
       "dismissible": false,
       "iconClassNames": Array [],
       "id": "error",
@@ -1831,7 +1831,7 @@ ShallowWrapper {
       "nodeType": "function",
       "props": Object {
         "alertType": "danger",
-        "className": Array [],
+        "className": "",
         "dismissible": false,
         "iconClassNames": Array [],
         "id": "error",
@@ -1952,7 +1952,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
@@ -2029,7 +2029,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -2082,7 +2082,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -2150,7 +2150,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
@@ -2221,7 +2221,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -2298,7 +2298,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -2351,7 +2351,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
@@ -2419,7 +2419,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",
@@ -2549,7 +2549,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
@@ -2626,7 +2626,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -2679,7 +2679,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -2747,7 +2747,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
@@ -2818,7 +2818,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -2895,7 +2895,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -2948,7 +2948,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
@@ -3016,7 +3016,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",
@@ -3146,7 +3146,7 @@ ShallowWrapper {
             />
             <StatusAlert
               alertType="danger"
-              className={Array []}
+              className=""
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
@@ -3223,7 +3223,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -3276,7 +3276,7 @@ ShallowWrapper {
                 />,
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -3344,7 +3344,7 @@ ShallowWrapper {
                 "nodeType": "function",
                 "props": Object {
                   "alertType": "danger",
-                  "className": Array [],
+                  "className": "",
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
@@ -3415,7 +3415,7 @@ ShallowWrapper {
               />
               <StatusAlert
                 alertType="danger"
-                className={Array []}
+                className=""
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
@@ -3492,7 +3492,7 @@ ShallowWrapper {
                 />
                 <StatusAlert
                   alertType="danger"
-                  className={Array []}
+                  className=""
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
@@ -3545,7 +3545,7 @@ ShallowWrapper {
                   />,
                   <StatusAlert
                     alertType="danger"
-                    className={Array []}
+                    className=""
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
@@ -3613,7 +3613,7 @@ ShallowWrapper {
                   "nodeType": "function",
                   "props": Object {
                     "alertType": "danger",
-                    "className": Array [],
+                    "className": "",
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",

--- a/src/components/StatusAlert/__snapshots__/StatusAlert.test.jsx.snap
+++ b/src/components/StatusAlert/__snapshots__/StatusAlert.test.jsx.snap
@@ -5,7 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <StatusAlert
     alertType="Test"
-    className={Array []}
+    className=""
     dismissible={false}
     iconClassNames={Array []}
     message="Test Message"
@@ -27,7 +27,7 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "alertType": "Test",
-      "className": Array [],
+      "className": "",
       "dialog": <div
         className=""
       >
@@ -52,7 +52,7 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "alertType": "Test",
-        "className": Array [],
+        "className": "",
         "dialog": <div
           className=""
         >

--- a/src/components/StatusAlert/index.jsx
+++ b/src/components/StatusAlert/index.jsx
@@ -47,7 +47,7 @@ const StatusAlert = (props) => {
 StatusAlert.propTypes = {
   alertType: PropTypes.string.isRequired,
   message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-  className: PropTypes.arrayOf(PropTypes.string),
+  className: PropTypes.string,
   iconClassNames: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
   dismissible: PropTypes.bool,
@@ -55,7 +55,7 @@ StatusAlert.propTypes = {
 };
 
 StatusAlert.defaultProps = {
-  className: [],
+  className: '',
   iconClassNames: [],
   title: null,
   dismissible: false,

--- a/src/components/TableComponent/TableComponent.test.jsx
+++ b/src/components/TableComponent/TableComponent.test.jsx
@@ -38,6 +38,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -55,6 +56,7 @@ describe('CourseTable', () => {
       formatData={mockFormat}
       error={new Error('Test error')}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -71,6 +73,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -88,6 +91,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -105,6 +109,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -122,6 +127,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}
@@ -144,6 +150,7 @@ describe('CourseTable', () => {
       columns={mockColumns}
       formatData={mockFormat}
       tableSortable
+      pageCount={1}
       paginateTable={() => true}
       sortTable={() => true}
       clearTable={() => true}

--- a/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
+++ b/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
@@ -42,6 +42,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -122,6 +123,7 @@ ShallowWrapper {
               currentPage={1}
               maxPagesDisplayed={7}
               onPageSelect={[Function]}
+              pageCount={1}
               paginationLabel="test-pagination"
             />
           </div>
@@ -195,6 +197,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>,
@@ -306,6 +309,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />,
               "className": "mt-2 d-flex justify-content-center",
@@ -327,7 +331,7 @@ ShallowWrapper {
                 "currentPage": 1,
                 "maxPagesDisplayed": 7,
                 "onPageSelect": [Function],
-                "pageCount": undefined,
+                "pageCount": 1,
                 "paginationLabel": "test-pagination",
               },
               "ref": null,
@@ -410,6 +414,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>
@@ -483,6 +488,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />
               </div>,
@@ -594,6 +600,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />,
                 "className": "mt-2 d-flex justify-content-center",
@@ -615,7 +622,7 @@ ShallowWrapper {
                   "currentPage": 1,
                   "maxPagesDisplayed": 7,
                   "onPageSelect": [Function],
-                  "pageCount": undefined,
+                  "pageCount": 1,
                   "paginationLabel": "test-pagination",
                 },
                 "ref": null,
@@ -700,6 +707,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=-key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -780,6 +788,7 @@ ShallowWrapper {
               currentPage={1}
               maxPagesDisplayed={7}
               onPageSelect={[Function]}
+              pageCount={1}
               paginationLabel="test-pagination"
             />
           </div>
@@ -853,6 +862,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>,
@@ -964,6 +974,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />,
               "className": "mt-2 d-flex justify-content-center",
@@ -985,7 +996,7 @@ ShallowWrapper {
                 "currentPage": 1,
                 "maxPagesDisplayed": 7,
                 "onPageSelect": [Function],
-                "pageCount": undefined,
+                "pageCount": 1,
                 "paginationLabel": "test-pagination",
               },
               "ref": null,
@@ -1068,6 +1079,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>
@@ -1141,6 +1153,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />
               </div>,
@@ -1252,6 +1265,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />,
                 "className": "mt-2 d-flex justify-content-center",
@@ -1273,7 +1287,7 @@ ShallowWrapper {
                   "currentPage": 1,
                   "maxPagesDisplayed": 7,
                   "onPageSelect": [Function],
-                  "pageCount": undefined,
+                  "pageCount": 1,
                   "paginationLabel": "test-pagination",
                 },
                 "ref": null,
@@ -1358,6 +1372,7 @@ ShallowWrapper {
         "search": "?page=2&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -1438,6 +1453,7 @@ ShallowWrapper {
               currentPage={1}
               maxPagesDisplayed={7}
               onPageSelect={[Function]}
+              pageCount={1}
               paginationLabel="test-pagination"
             />
           </div>
@@ -1511,6 +1527,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>,
@@ -1622,6 +1639,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />,
               "className": "mt-2 d-flex justify-content-center",
@@ -1643,7 +1661,7 @@ ShallowWrapper {
                 "currentPage": 1,
                 "maxPagesDisplayed": 7,
                 "onPageSelect": [Function],
-                "pageCount": undefined,
+                "pageCount": 1,
                 "paginationLabel": "test-pagination",
               },
               "ref": null,
@@ -1726,6 +1744,7 @@ ShallowWrapper {
                 currentPage={1}
                 maxPagesDisplayed={7}
                 onPageSelect={[Function]}
+                pageCount={1}
                 paginationLabel="test-pagination"
               />
             </div>
@@ -1799,6 +1818,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />
               </div>,
@@ -1910,6 +1930,7 @@ ShallowWrapper {
                   currentPage={1}
                   maxPagesDisplayed={7}
                   onPageSelect={[Function]}
+                  pageCount={1}
                   paginationLabel="test-pagination"
                 />,
                 "className": "mt-2 d-flex justify-content-center",
@@ -1931,7 +1952,7 @@ ShallowWrapper {
                   "currentPage": 1,
                   "maxPagesDisplayed": 7,
                   "onPageSelect": [Function],
-                  "pageCount": undefined,
+                  "pageCount": 1,
                   "paginationLabel": "test-pagination",
                 },
                 "ref": null,
@@ -2004,6 +2025,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -2119,6 +2141,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -2142,7 +2165,7 @@ ShallowWrapper {
         false,
         <StatusAlert
           alertType="warning"
-          className={Array []}
+          className=""
           dismissible={false}
           iconClassNames={
             Array [
@@ -2167,7 +2190,7 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "alertType": "warning",
-          "className": Array [],
+          "className": "",
           "dismissible": false,
           "iconClassNames": Array [
             "fa",
@@ -2196,7 +2219,7 @@ ShallowWrapper {
           false,
           <StatusAlert
             alertType="warning"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={
               Array [
@@ -2221,7 +2244,7 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "alertType": "warning",
-            "className": Array [],
+            "className": "",
             "dismissible": false,
             "iconClassNames": Array [
               "fa",
@@ -2297,6 +2320,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}
@@ -2318,7 +2342,7 @@ ShallowWrapper {
       "children": Array [
         <StatusAlert
           alertType="danger"
-          className={Array []}
+          className=""
           dismissible={false}
           iconClassNames={
             Array [
@@ -2343,7 +2367,7 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "alertType": "danger",
-          "className": Array [],
+          "className": "",
           "dismissible": false,
           "iconClassNames": Array [
             "fa",
@@ -2372,7 +2396,7 @@ ShallowWrapper {
         "children": Array [
           <StatusAlert
             alertType="danger"
-            className={Array []}
+            className=""
             dismissible={false}
             iconClassNames={
               Array [
@@ -2397,7 +2421,7 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "alertType": "danger",
-            "className": Array [],
+            "className": "",
             "dismissible": false,
             "iconClassNames": Array [
               "fa",
@@ -2475,6 +2499,7 @@ ShallowWrapper {
         "search": "?page=1&ordering=key",
       }
     }
+    pageCount={1}
     paginateTable={[Function]}
     sortTable={[Function]}
     tableSortable={true}

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -146,7 +146,7 @@ TableComponent.propTypes = {
   // Props expected from TableContainer / redux store
   data: PropTypes.arrayOf(PropTypes.shape({})),
   currentPage: PropTypes.number,
-  pageCount: PropTypes.number,
+  pageCount: PropTypes.number.isRequired,
   ordering: PropTypes.string,
   loading: PropTypes.bool,
   error: PropTypes.instanceOf(Error),
@@ -159,12 +159,11 @@ TableComponent.propTypes = {
 };
 
 TableComponent.defaultProps = {
-  className: null,
+  className: '',
   tableSortable: false,
   data: undefined,
   ordering: undefined,
   currentPage: undefined,
-  pageCount: undefined,
   error: null,
   loading: false,
 };

--- a/src/containers/TableContainer/index.jsx
+++ b/src/containers/TableContainer/index.jsx
@@ -9,7 +9,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     data: tableState.data && tableState.data.results,
     currentPage: tableState.data && tableState.page,
-    pageCount: tableState.data && Math.ceil(tableState.data.count / tableState.pageSize),
+    pageCount: (tableState.data && Math.ceil(tableState.data.count / tableState.pageSize)) || 1,
     ordering: tableState.ordering,
     loading: tableState.loading,
     error: tableState.error,


### PR DESCRIPTION
…ining go_live_date internally to keep a separation from the word publish

This PR also includes a number of warning fixes over lower components requiring props that our components did not. The fixes were either to make it required in our component as well, or to supply a default prop so we always have a value of the appropriate type rather than undefined.