### PR TITLE
DISCO-843: Fixes error messaging

### DIFF
--- a/src/components/CreateCoursePage/CreateCoursePage.test.jsx
+++ b/src/components/CreateCoursePage/CreateCoursePage.test.jsx
@@ -50,7 +50,7 @@ describe('CreateCoursePage', () => {
       fetchOrganizations={() => null}
       publisherUserInfo={{
         organizations,
-        error: 'Fail',
+        error: ['Fail'],
         isFetching: false,
       }}
       courseInfo={{
@@ -84,7 +84,7 @@ describe('CreateCoursePage', () => {
         isFetching: false,
       }}
       courseInfo={{
-        error: 'Fail',
+        error: ['Fail'],
         isCreating: false,
         data: {},
       }}

--- a/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
+++ b/src/components/CreateCoursePage/__snapshots__/CreateCoursePage.test.jsx.snap
@@ -82,7 +82,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             undefined,
-            undefined,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -98,7 +97,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           undefined,
-          undefined,
           Object {
             "instance": null,
             "key": undefined,
@@ -111,7 +109,7 @@ ShallowWrapper {
                   onSubmit={[Function]}
                   organizations={Array []}
                 />,
-                undefined,
+                false,
               ],
             },
             "ref": null,
@@ -131,7 +129,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              undefined,
+              false,
             ],
             "type": "div",
           },
@@ -205,7 +203,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               undefined,
-              undefined,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -221,7 +218,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             undefined,
-            undefined,
             Object {
               "instance": null,
               "key": undefined,
@@ -234,7 +230,7 @@ ShallowWrapper {
                     onSubmit={[Function]}
                     organizations={Array []}
                   />,
-                  undefined,
+                  false,
                 ],
               },
               "ref": null,
@@ -254,7 +250,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                undefined,
+                false,
               ],
               "type": "div",
             },
@@ -383,7 +379,6 @@ ShallowWrapper {
             <LoadingSpinner
               message="Loading…"
             />,
-            null,
             false,
           ],
           "className": "",
@@ -402,7 +397,6 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          null,
           false,
         ],
         "type": [Function],
@@ -471,7 +465,6 @@ ShallowWrapper {
               <LoadingSpinner
                 message="Loading…"
               />,
-              null,
               false,
             ],
             "className": "",
@@ -490,7 +483,6 @@ ShallowWrapper {
               "rendered": null,
               "type": [Function],
             },
-            null,
             false,
           ],
           "type": [Function],
@@ -533,7 +525,9 @@ ShallowWrapper {
     courseInfo={
       Object {
         "data": Object {},
-        "error": "Fail",
+        "error": Array [
+          "Fail",
+        ],
         "isCreating": false,
       }
     }
@@ -609,7 +603,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="create-error"
-              message="Fail"
+              message={
+                Array [
+                  "Fail",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -651,7 +650,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             false,
-            null,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -677,7 +675,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -689,7 +692,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           false,
-          null,
           Object {
             "instance": null,
             "key": undefined,
@@ -720,7 +722,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />,
@@ -762,7 +769,10 @@ ShallowWrapper {
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-error",
-                  "message": "Fail",
+                  "message": Array [
+                    "Fail",
+                    <br />,
+                  ],
                   "onClose": [Function],
                   "title": null,
                 },
@@ -823,7 +833,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -865,7 +880,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               false,
-              null,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -891,7 +905,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />
@@ -903,7 +922,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             false,
-            null,
             Object {
               "instance": null,
               "key": undefined,
@@ -934,7 +952,12 @@ ShallowWrapper {
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-error"
-                    message="Fail"
+                    message={
+                      Array [
+                        "Fail",
+                        <br />,
+                      ]
+                    }
                     onClose={[Function]}
                     title={null}
                   />,
@@ -976,7 +999,10 @@ ShallowWrapper {
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-error",
-                    "message": "Fail",
+                    "message": Array [
+                      "Fail",
+                      <br />,
+                    ],
                     "onClose": [Function],
                     "title": null,
                   },
@@ -1138,7 +1164,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             false,
-            null,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -1166,7 +1191,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           false,
-          null,
           Object {
             "instance": null,
             "key": undefined,
@@ -1191,7 +1215,7 @@ ShallowWrapper {
                     ]
                   }
                 />,
-                null,
+                false,
               ],
             },
             "ref": null,
@@ -1220,7 +1244,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              false,
             ],
             "type": "div",
           },
@@ -1306,7 +1330,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               false,
-              null,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -1334,7 +1357,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             false,
-            null,
             Object {
               "instance": null,
               "key": undefined,
@@ -1359,7 +1381,7 @@ ShallowWrapper {
                       ]
                     }
                   />,
-                  null,
+                  false,
                 ],
               },
               "ref": null,
@@ -1388,7 +1410,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                false,
               ],
               "type": "div",
             },
@@ -1543,7 +1565,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             false,
-            null,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -1571,7 +1592,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           false,
-          null,
           Object {
             "instance": null,
             "key": undefined,
@@ -1596,7 +1616,7 @@ ShallowWrapper {
                     ]
                   }
                 />,
-                null,
+                false,
               ],
             },
             "ref": null,
@@ -1625,7 +1645,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              false,
             ],
             "type": "div",
           },
@@ -1711,7 +1731,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               false,
-              null,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -1739,7 +1758,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             false,
-            null,
             Object {
               "instance": null,
               "key": undefined,
@@ -1764,7 +1782,7 @@ ShallowWrapper {
                       ]
                     }
                   />,
-                  null,
+                  false,
                 ],
               },
               "ref": null,
@@ -1793,7 +1811,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                false,
               ],
               "type": "div",
             },
@@ -1937,7 +1955,9 @@ ShallowWrapper {
     initialValues={Object {}}
     publisherUserInfo={
       Object {
-        "error": "Fail",
+        "error": Array [
+          "Fail",
+        ],
         "isFetching": false,
         "organizations": Array [
           Object {
@@ -1979,16 +1999,6 @@ ShallowWrapper {
           className=""
           wide={false}
         >
-          <StatusAlert
-            alertType="danger"
-            className=""
-            dismissible={false}
-            iconClassNames={Array []}
-            id="user-info-error"
-            message="Fail"
-            onClose={[Function]}
-            title={null}
-          />
           <div>
             <ReduxForm
               id="create-course-form"
@@ -2007,6 +2017,21 @@ ShallowWrapper {
                   },
                 ]
               }
+            />
+            <StatusAlert
+              alertType="danger"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              id="create-error"
+              message={
+                Array [
+                  "Fail",
+                  <br />,
+                ]
+              }
+              onClose={[Function]}
+              title={null}
             />
           </div>
         </PageContainer>,
@@ -2046,16 +2071,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             false,
-            <StatusAlert
-              alertType="danger"
-              className=""
-              dismissible={false}
-              iconClassNames={Array []}
-              id="user-info-error"
-              message="Fail"
-              onClose={[Function]}
-              title={null}
-            />,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -2075,6 +2090,21 @@ ShallowWrapper {
                   ]
                 }
               />
+              <StatusAlert
+                alertType="danger"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                id="create-error"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
+                onClose={[Function]}
+                title={null}
+              />
             </div>,
           ],
           "className": "",
@@ -2083,24 +2113,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           false,
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "alertType": "danger",
-              "className": "",
-              "dismissible": false,
-              "iconClassNames": Array [],
-              "id": "user-info-error",
-              "message": "Fail",
-              "onClose": [Function],
-              "title": null,
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
           Object {
             "instance": null,
             "key": undefined,
@@ -2125,7 +2137,21 @@ ShallowWrapper {
                     ]
                   }
                 />,
-                null,
+                <StatusAlert
+                  alertType="danger"
+                  className=""
+                  dismissible={false}
+                  iconClassNames={Array []}
+                  id="create-error"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
+                  onClose={[Function]}
+                  title={null}
+                />,
               ],
             },
             "ref": null,
@@ -2154,7 +2180,27 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "alertType": "danger",
+                  "className": "",
+                  "dismissible": false,
+                  "iconClassNames": Array [],
+                  "id": "create-error",
+                  "message": Array [
+                    "Fail",
+                    <br />,
+                  ],
+                  "onClose": [Function],
+                  "title": null,
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
             ],
             "type": "div",
           },
@@ -2183,16 +2229,6 @@ ShallowWrapper {
             className=""
             wide={false}
           >
-            <StatusAlert
-              alertType="danger"
-              className=""
-              dismissible={false}
-              iconClassNames={Array []}
-              id="user-info-error"
-              message="Fail"
-              onClose={[Function]}
-              title={null}
-            />
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -2211,6 +2247,21 @@ ShallowWrapper {
                     },
                   ]
                 }
+              />
+              <StatusAlert
+                alertType="danger"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                id="create-error"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
+                onClose={[Function]}
+                title={null}
               />
             </div>
           </PageContainer>,
@@ -2250,16 +2301,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               false,
-              <StatusAlert
-                alertType="danger"
-                className=""
-                dismissible={false}
-                iconClassNames={Array []}
-                id="user-info-error"
-                message="Fail"
-                onClose={[Function]}
-                title={null}
-              />,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -2279,6 +2320,21 @@ ShallowWrapper {
                     ]
                   }
                 />
+                <StatusAlert
+                  alertType="danger"
+                  className=""
+                  dismissible={false}
+                  iconClassNames={Array []}
+                  id="create-error"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
+                  onClose={[Function]}
+                  title={null}
+                />
               </div>,
             ],
             "className": "",
@@ -2287,24 +2343,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             false,
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "alertType": "danger",
-                "className": "",
-                "dismissible": false,
-                "iconClassNames": Array [],
-                "id": "user-info-error",
-                "message": "Fail",
-                "onClose": [Function],
-                "title": null,
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
             Object {
               "instance": null,
               "key": undefined,
@@ -2329,7 +2367,21 @@ ShallowWrapper {
                       ]
                     }
                   />,
-                  null,
+                  <StatusAlert
+                    alertType="danger"
+                    className=""
+                    dismissible={false}
+                    iconClassNames={Array []}
+                    id="create-error"
+                    message={
+                      Array [
+                        "Fail",
+                        <br />,
+                      ]
+                    }
+                    onClose={[Function]}
+                    title={null}
+                  />,
                 ],
               },
               "ref": null,
@@ -2358,7 +2410,27 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "alertType": "danger",
+                    "className": "",
+                    "dismissible": false,
+                    "iconClassNames": Array [],
+                    "id": "create-error",
+                    "message": Array [
+                      "Fail",
+                      <br />,
+                    ],
+                    "onClose": [Function],
+                    "title": null,
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
               ],
               "type": "div",
             },
@@ -2511,7 +2583,6 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             false,
-            null,
             <div>
               <ReduxForm
                 id="create-course-form"
@@ -2539,7 +2610,6 @@ ShallowWrapper {
         "ref": null,
         "rendered": Array [
           false,
-          null,
           Object {
             "instance": null,
             "key": undefined,
@@ -2564,7 +2634,7 @@ ShallowWrapper {
                     ]
                   }
                 />,
-                null,
+                false,
               ],
             },
             "ref": null,
@@ -2593,7 +2663,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              false,
             ],
             "type": "div",
           },
@@ -2679,7 +2749,6 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               false,
-              null,
               <div>
                 <ReduxForm
                   id="create-course-form"
@@ -2707,7 +2776,6 @@ ShallowWrapper {
           "ref": null,
           "rendered": Array [
             false,
-            null,
             Object {
               "instance": null,
               "key": undefined,
@@ -2732,7 +2800,7 @@ ShallowWrapper {
                       ]
                     }
                   />,
-                  null,
+                  false,
                 ],
               },
               "ref": null,
@@ -2761,7 +2829,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                false,
               ],
               "type": "div",
             },

--- a/src/components/CreateCoursePage/index.jsx
+++ b/src/components/CreateCoursePage/index.jsx
@@ -52,6 +52,25 @@ class CreateCoursePage extends React.Component {
 
     const organizations = publisherUserInfo.organizations ? publisherUserInfo.organizations : [];
 
+    const errorArray = [];
+    if (courseInfo.error) {
+      courseInfo.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < courseInfo.error.length) {
+          errorArray.push(<br />);
+        }
+      });
+    }
+
+    if (publisherUserInfo.error) {
+      publisherUserInfo.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < publisherUserInfo.error.length) {
+          errorArray.push(<br />);
+        }
+      });
+    }
+
     return (
       <React.Fragment>
         <Helmet>
@@ -60,13 +79,6 @@ class CreateCoursePage extends React.Component {
 
         <PageContainer>
           { publisherUserInfo.isFetching && <LoadingSpinner /> }
-          { publisherUserInfo.error && (
-            <StatusAlert
-              id="user-info-error"
-              alertType="danger"
-              message={publisherUserInfo.error}
-            />
-          )}
           { !publisherUserInfo.isFetching &&
           (
             <div>
@@ -77,11 +89,11 @@ class CreateCoursePage extends React.Component {
                 organizations={organizations}
                 isCreating={courseInfo.isCreating}
               />
-              {courseInfo.error && (
+              {errorArray.length > 1 && (
                 <StatusAlert
                   id="create-error"
                   alertType="danger"
-                  message={courseInfo.error}
+                  message={errorArray}
                 />
               ) }
             </div>
@@ -112,11 +124,11 @@ CreateCoursePage.propTypes = {
   }),
   publisherUserInfo: PropTypes.shape({
     organizations: PropTypes.array,
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   courseInfo: PropTypes.shape({
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     data: PropTypes.shape({
       uuid: PropTypes.string,
     }),

--- a/src/components/CreateCourseRunPage/CreateCourseRunPage.test.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunPage.test.jsx
@@ -47,7 +47,7 @@ describe('CreateCourseRunPage', () => {
         data: {},
         isFetching: false,
         isCreating: false,
-        error: 'failed',
+        error: ['failed'],
       }}
     />);
     expect(component).toMatchSnapshot();

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -102,7 +102,7 @@ ShallowWrapper {
                   title=""
                   uuid=""
                 />,
-                null,
+                false,
               ],
             },
             "ref": null,
@@ -121,7 +121,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              false,
             ],
             "type": "div",
           },
@@ -208,7 +208,7 @@ ShallowWrapper {
                     title=""
                     uuid=""
                   />,
-                  null,
+                  false,
                 ],
               },
               "ref": null,
@@ -227,7 +227,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                false,
               ],
               "type": "div",
             },
@@ -367,7 +367,7 @@ ShallowWrapper {
                   title=""
                   uuid=""
                 />,
-                null,
+                false,
               ],
             },
             "ref": null,
@@ -386,7 +386,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              null,
+              false,
             ],
             "type": "div",
           },
@@ -473,7 +473,7 @@ ShallowWrapper {
                     title=""
                     uuid=""
                   />,
-                  null,
+                  false,
                 ],
               },
               "ref": null,
@@ -492,7 +492,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                null,
+                false,
               ],
               "type": "div",
             },
@@ -537,7 +537,9 @@ ShallowWrapper {
     courseInfo={
       Object {
         "data": Object {},
-        "error": "failed",
+        "error": Array [
+          "failed",
+        ],
         "isCreating": false,
         "isFetching": false,
       }
@@ -585,7 +587,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="create-error"
-              message="failed"
+              message={
+                Array [
+                  "failed",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -628,7 +635,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
-                message="failed"
+                message={
+                  Array [
+                    "failed",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -658,7 +670,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
-                  message="failed"
+                  message={
+                    Array [
+                      "failed",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />,
@@ -690,7 +707,10 @@ ShallowWrapper {
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-error",
-                  "message": "failed",
+                  "message": Array [
+                    "failed",
+                    <br />,
+                  ],
                   "onClose": [Function],
                   "title": null,
                 },
@@ -737,7 +757,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-error"
-                message="failed"
+                message={
+                  Array [
+                    "failed",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -780,7 +805,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-error"
-                  message="failed"
+                  message={
+                    Array [
+                      "failed",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />
@@ -810,7 +840,12 @@ ShallowWrapper {
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-error"
-                    message="failed"
+                    message={
+                      Array [
+                        "failed",
+                        <br />,
+                      ]
+                    }
                     onClose={[Function]}
                     title={null}
                   />,
@@ -842,7 +877,10 @@ ShallowWrapper {
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-error",
-                    "message": "failed",
+                    "message": Array [
+                      "failed",
+                      <br />,
+                    ],
                     "onClose": [Function],
                     "title": null,
                   },

--- a/src/components/CreateCourseRunPage/index.jsx
+++ b/src/components/CreateCourseRunPage/index.jsx
@@ -39,6 +39,16 @@ class CreateCourseRunPage extends React.Component {
     const title = courseInfo.data && courseInfo.data.title ? courseInfo.data.title : '';
     const uuid = courseInfo.data && courseInfo.data.uuid ? courseInfo.data.uuid : '';
 
+    const errorArray = [];
+    if (courseInfo.error) {
+      courseInfo.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < courseInfo.error.length) {
+          errorArray.push(<br />);
+        }
+      });
+    }
+
     return (
       <React.Fragment>
         <Helmet>
@@ -56,11 +66,11 @@ class CreateCourseRunPage extends React.Component {
                 uuid={uuid}
                 isCreating={courseInfo.isCreating}
               />
-              {courseInfo.error && (
+              {errorArray.length > 1 && (
                 <StatusAlert
                   id="create-error"
                   alertType="danger"
-                  message={courseInfo.error}
+                  message={errorArray}
                 />
               ) }
             </div>
@@ -86,7 +96,7 @@ CreateCourseRunPage.propTypes = {
   fetchCourseInfo: PropTypes.func,
   courseInfo: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   id: PropTypes.string.isRequired,

--- a/src/components/EditCoursePage/CollapsibleCourseRunFields.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRunFields.jsx
@@ -19,7 +19,7 @@ const formatCourseRunTitle = (courseRun) => {
   if (courseRun) {
     const labelItems = [];
     if (courseRun.start) {
-      labelItems.push(moment(courseRun.start).format('MMM Do YYYY'));
+      labelItems.push(moment.utc(courseRun.start).format('MMM Do YYYY'));
     }
     if (courseRun.pacing_type) {
       labelItems.push(courseRun.pacing_type.split('_').map(pacingType =>
@@ -56,7 +56,7 @@ const formatCourseRunTitle = (courseRun) => {
   );
 };
 
-const getDateString = date => (date ? moment(date).format('YYYY-MM-DD') : '');
+const getDateString = date => (date ? moment.utc(date).format('YYYY-MM-DD') : '');
 
 const CollapsibleCourseRunFields = ({
   fields,
@@ -116,7 +116,7 @@ const CollapsibleCourseRunFields = ({
             type="date"
             component={RenderInputTextField}
             format={value => getDateString(value)}
-            normalize={value => moment(value).toISOString()}
+            normalize={value => moment.utc(value).toISOString()}
             label={
               <FieldLabel
                 id={`${courseRun}.end.label`}
@@ -143,7 +143,7 @@ const CollapsibleCourseRunFields = ({
             type="date"
             component={RenderInputTextField}
             format={value => getDateString(value)}
-            normalize={value => moment(value).toISOString()}
+            normalize={value => moment.utc(value).toISOString()}
             label={
               <FieldLabel
                 id={`${courseRun}.go_live_date.label`}

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -688,12 +688,12 @@ BaseEditCourseForm.propTypes = {
   entitlement: PropTypes.bool,
   courseOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }).isRequired,
   courseRunOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }).isRequired,
   submitting: PropTypes.bool,

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -163,7 +163,7 @@ describe('EditCoursePage', () => {
       courseInfo={{
         data: {},
         isFetching: false,
-        error: 'Course Info error.',
+        error: ['Course Info error.'],
       }}
     />);
     expect(component).toMatchSnapshot();
@@ -188,7 +188,7 @@ describe('EditCoursePage', () => {
       courseOptions={{
         data: {},
         isFetching: false,
-        error: 'Course Options error.',
+        error: ['Course Options error.'],
       }}
     />);
     expect(component).toMatchSnapshot();
@@ -228,7 +228,7 @@ describe('EditCoursePage', () => {
       courseRunOptions={{
         data: {},
         isFetching: false,
-        error: 'Course Run Options error.',
+        error: ['Course Run Options error.'],
       }}
     />);
     expect(component).toMatchSnapshot();
@@ -239,17 +239,17 @@ describe('EditCoursePage', () => {
       courseInfo={{
         data: {},
         isFetching: false,
-        error: 'Course Info error.',
+        error: ['Course Info error.'],
       }}
       courseOptions={{
         data: {},
         isFetching: false,
-        error: 'Course Options error.',
+        error: ['Course Options error.'],
       }}
       courseRunOptions={{
         data: {},
         isFetching: false,
-        error: 'Course Run Options error.',
+        error: ['Course Run Options error.'],
       }}
     />);
     expect(component).toMatchSnapshot();

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -87,7 +87,6 @@ ShallowWrapper {
               targetRun={null}
             />
           </div>
-          
         </PageContainer>,
       ],
     },
@@ -169,7 +168,7 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -280,7 +279,7 @@ ShallowWrapper {
             },
             "type": "div",
           },
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -350,7 +349,6 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>
-            
           </PageContainer>,
         ],
       },
@@ -432,7 +430,7 @@ ShallowWrapper {
                   targetRun={null}
                 />
               </div>,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -543,7 +541,7 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -632,7 +630,6 @@ ShallowWrapper {
           <LoadingSpinner
             message="Loading…"
           />
-          
         </PageContainer>,
       ],
     },
@@ -673,7 +670,7 @@ ShallowWrapper {
               message="Loading…"
             />,
             false,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -692,7 +689,7 @@ ShallowWrapper {
             "type": [Function],
           },
           false,
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -721,7 +718,6 @@ ShallowWrapper {
             <LoadingSpinner
               message="Loading…"
             />
-            
           </PageContainer>,
         ],
       },
@@ -762,7 +758,7 @@ ShallowWrapper {
                 message="Loading…"
               />,
               false,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -781,7 +777,7 @@ ShallowWrapper {
               "type": [Function],
             },
             false,
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -1016,7 +1012,6 @@ ShallowWrapper {
               uuid="00000000-0000-0000-0000-000000000000"
             />
           </div>
-          
         </PageContainer>,
       ],
     },
@@ -1156,7 +1151,7 @@ ShallowWrapper {
                 uuid="00000000-0000-0000-0000-000000000000"
               />
             </div>,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -1380,7 +1375,7 @@ ShallowWrapper {
             },
             "type": "div",
           },
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -1508,7 +1503,6 @@ ShallowWrapper {
                 uuid="00000000-0000-0000-0000-000000000000"
               />
             </div>
-            
           </PageContainer>,
         ],
       },
@@ -1648,7 +1642,7 @@ ShallowWrapper {
                   uuid="00000000-0000-0000-0000-000000000000"
                 />
               </div>,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -1872,7 +1866,7 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -2205,7 +2199,6 @@ ShallowWrapper {
               uuid="00000000-0000-0000-0000-000000000000"
             />
           </div>
-          
         </PageContainer>,
       ],
     },
@@ -2394,7 +2387,7 @@ ShallowWrapper {
                 uuid="00000000-0000-0000-0000-000000000000"
               />
             </div>,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -2714,7 +2707,7 @@ ShallowWrapper {
             },
             "type": "div",
           },
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -2891,7 +2884,6 @@ ShallowWrapper {
                 uuid="00000000-0000-0000-0000-000000000000"
               />
             </div>
-            
           </PageContainer>,
         ],
       },
@@ -3080,7 +3072,7 @@ ShallowWrapper {
                   uuid="00000000-0000-0000-0000-000000000000"
                 />
               </div>,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -3400,7 +3392,7 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -3442,7 +3434,9 @@ ShallowWrapper {
     courseInfo={
       Object {
         "data": Object {},
-        "error": "Course Info error.",
+        "error": Array [
+          "Course Info error.",
+        ],
         "isFetching": false,
       }
     }
@@ -3486,7 +3480,12 @@ ShallowWrapper {
             dismissible={false}
             iconClassNames={Array []}
             id="error"
-            message="Course Info error. Please try reloading the page and if the error persists, please contact support."
+            message={
+              Array [
+                "Course Info error.",
+                <br />,
+              ]
+            }
             onClose={[Function]}
             title={null}
           />
@@ -3534,7 +3533,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Info error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Info error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />,
@@ -3556,7 +3560,10 @@ ShallowWrapper {
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
-              "message": "Course Info error. Please try reloading the page and if the error persists, please contact support.",
+              "message": Array [
+                "Course Info error.",
+                <br />,
+              ],
               "onClose": [Function],
               "title": null,
             },
@@ -3595,7 +3602,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Info error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Info error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -3643,7 +3655,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
-                message="Course Info error. Please try reloading the page and if the error persists, please contact support."
+                message={
+                  Array [
+                    "Course Info error.",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />,
@@ -3665,7 +3682,10 @@ ShallowWrapper {
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
-                "message": "Course Info error. Please try reloading the page and if the error persists, please contact support.",
+                "message": Array [
+                  "Course Info error.",
+                  <br />,
+                ],
                 "onClose": [Function],
                 "title": null,
               },
@@ -3714,21 +3734,27 @@ ShallowWrapper {
     courseInfo={
       Object {
         "data": Object {},
-        "error": "Course Info error.",
+        "error": Array [
+          "Course Info error.",
+        ],
         "isFetching": false,
       }
     }
     courseOptions={
       Object {
         "data": Object {},
-        "error": "Course Options error.",
+        "error": Array [
+          "Course Options error.",
+        ],
         "isFetching": false,
       }
     }
     courseRunOptions={
       Object {
         "data": Object {},
-        "error": "Course Run Options error.",
+        "error": Array [
+          "Course Run Options error.",
+        ],
         "isFetching": false,
       }
     }
@@ -3770,7 +3796,16 @@ ShallowWrapper {
             dismissible={false}
             iconClassNames={Array []}
             id="error"
-            message="Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+            message={
+              Array [
+                "Course Info error.",
+                <br />,
+                "Course Options error.",
+                <br />,
+                "Course Run Options error.",
+                <br />,
+              ]
+            }
             onClose={[Function]}
             title={null}
           />
@@ -3818,7 +3853,16 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Info error.",
+                  <br />,
+                  "Course Options error.",
+                  <br />,
+                  "Course Run Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />,
@@ -3840,7 +3884,14 @@ ShallowWrapper {
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
-              "message": "Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support.",
+              "message": Array [
+                "Course Info error.",
+                <br />,
+                "Course Options error.",
+                <br />,
+                "Course Run Options error.",
+                <br />,
+              ],
               "onClose": [Function],
               "title": null,
             },
@@ -3879,7 +3930,16 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Info error.",
+                  <br />,
+                  "Course Options error.",
+                  <br />,
+                  "Course Run Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -3927,7 +3987,16 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
-                message="Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+                message={
+                  Array [
+                    "Course Info error.",
+                    <br />,
+                    "Course Options error.",
+                    <br />,
+                    "Course Run Options error.",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />,
@@ -3949,7 +4018,14 @@ ShallowWrapper {
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
-                "message": "Course Info error. Course Options error. Course Run Options error. Please try reloading the page and if the error persists, please contact support.",
+                "message": Array [
+                  "Course Info error.",
+                  <br />,
+                  "Course Options error.",
+                  <br />,
+                  "Course Run Options error.",
+                  <br />,
+                ],
                 "onClose": [Function],
                 "title": null,
               },
@@ -4176,7 +4252,6 @@ ShallowWrapper {
               targetRun={null}
             />
           </div>
-          
         </PageContainer>,
       ],
     },
@@ -4307,7 +4382,7 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -4514,7 +4589,7 @@ ShallowWrapper {
             },
             "type": "div",
           },
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -4633,7 +4708,6 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>
-            
           </PageContainer>,
         ],
       },
@@ -4764,7 +4838,7 @@ ShallowWrapper {
                   targetRun={null}
                 />
               </div>,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -4971,7 +5045,7 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -5018,7 +5092,9 @@ ShallowWrapper {
     courseOptions={
       Object {
         "data": Object {},
-        "error": "Course Options error.",
+        "error": Array [
+          "Course Options error.",
+        ],
         "isFetching": false,
       }
     }
@@ -5061,7 +5137,12 @@ ShallowWrapper {
             dismissible={false}
             iconClassNames={Array []}
             id="error"
-            message="Course Options error. Please try reloading the page and if the error persists, please contact support."
+            message={
+              Array [
+                "Course Options error.",
+                <br />,
+              ]
+            }
             onClose={[Function]}
             title={null}
           />
@@ -5109,7 +5190,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />,
@@ -5131,7 +5217,10 @@ ShallowWrapper {
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
-              "message": "Course Options error. Please try reloading the page and if the error persists, please contact support.",
+              "message": Array [
+                "Course Options error.",
+                <br />,
+              ],
               "onClose": [Function],
               "title": null,
             },
@@ -5170,7 +5259,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -5218,7 +5312,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
-                message="Course Options error. Please try reloading the page and if the error persists, please contact support."
+                message={
+                  Array [
+                    "Course Options error.",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />,
@@ -5240,7 +5339,10 @@ ShallowWrapper {
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
-                "message": "Course Options error. Please try reloading the page and if the error persists, please contact support.",
+                "message": Array [
+                  "Course Options error.",
+                  <br />,
+                ],
                 "onClose": [Function],
                 "title": null,
               },
@@ -5457,7 +5559,6 @@ ShallowWrapper {
               targetRun={null}
             />
           </div>
-          
         </PageContainer>,
       ],
     },
@@ -5583,7 +5684,7 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>,
-            "",
+            false,
           ],
           "className": "",
           "wide": false,
@@ -5780,7 +5881,7 @@ ShallowWrapper {
             },
             "type": "div",
           },
-          "",
+          false,
         ],
         "type": [Function],
       },
@@ -5894,7 +5995,6 @@ ShallowWrapper {
                 targetRun={null}
               />
             </div>
-            
           </PageContainer>,
         ],
       },
@@ -6020,7 +6120,7 @@ ShallowWrapper {
                   targetRun={null}
                 />
               </div>,
-              "",
+              false,
             ],
             "className": "",
             "wide": false,
@@ -6217,7 +6317,7 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            "",
+            false,
           ],
           "type": [Function],
         },
@@ -6265,7 +6365,9 @@ ShallowWrapper {
     courseRunOptions={
       Object {
         "data": Object {},
-        "error": "Course Run Options error.",
+        "error": Array [
+          "Course Run Options error.",
+        ],
         "isFetching": false,
       }
     }
@@ -6307,7 +6409,12 @@ ShallowWrapper {
             dismissible={false}
             iconClassNames={Array []}
             id="error"
-            message="Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+            message={
+              Array [
+                "Course Run Options error.",
+                <br />,
+              ]
+            }
             onClose={[Function]}
             title={null}
           />
@@ -6355,7 +6462,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Run Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />,
@@ -6377,7 +6489,10 @@ ShallowWrapper {
               "dismissible": false,
               "iconClassNames": Array [],
               "id": "error",
-              "message": "Course Run Options error. Please try reloading the page and if the error persists, please contact support.",
+              "message": Array [
+                "Course Run Options error.",
+                <br />,
+              ],
               "onClose": [Function],
               "title": null,
             },
@@ -6416,7 +6531,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="error"
-              message="Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+              message={
+                Array [
+                  "Course Run Options error.",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -6464,7 +6584,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="error"
-                message="Course Run Options error. Please try reloading the page and if the error persists, please contact support."
+                message={
+                  Array [
+                    "Course Run Options error.",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />,
@@ -6486,7 +6611,10 @@ ShallowWrapper {
                 "dismissible": false,
                 "iconClassNames": Array [],
                 "id": "error",
-                "message": "Course Run Options error. Please try reloading the page and if the error persists, please contact support.",
+                "message": Array [
+                  "Course Run Options error.",
+                  <br />,
+                ],
                 "onClose": [Function],
                 "title": null,
               },

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -231,22 +231,33 @@ class EditCoursePage extends React.Component {
     const mode = entitlement && entitlement.mode;
     const price = entitlement && entitlement.price;
 
-    let error = '';
+    const errorArray = [];
     if (courseInfo.error) {
-      error = error.concat(courseInfo.error, ' ');
+      courseInfo.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < courseInfo.error.length) {
+          errorArray.push(<br />);
+        }
+      });
     }
     if (courseOptions.error) {
-      error = error.concat(courseOptions.error, ' ');
+      courseOptions.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < courseOptions.error.length) {
+          errorArray.push(<br />);
+        }
+      });
     }
     if (courseRunOptions.error) {
-      error = error.concat(courseRunOptions.error, ' ');
+      courseRunOptions.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < courseRunOptions.error.length) {
+          errorArray.push(<br />);
+        }
+      });
     }
-    if (error) {
-      error += 'Please try reloading the page and if the error persists, please contact support.';
-    }
-    error = error.trim();
     const showSpinner = !startedFetching || courseInfo.isFetching || courseOptions.isFetching;
-    const showForm = !error && startedFetching && !courseInfo.isFetching &&
+    const showForm = errorArray.length < 1 && startedFetching && !courseInfo.isFetching &&
       !courseOptions.isFetching;
 
     return (
@@ -298,11 +309,11 @@ class EditCoursePage extends React.Component {
               />
             </div>
           )}
-          { error && (
+          { errorArray.length > 0 && (
             <StatusAlert
               id="error"
               alertType="danger"
-              message={error}
+              message={errorArray}
             />
           )}
         </PageContainer>
@@ -326,17 +337,17 @@ EditCoursePage.defaultProps = {
 EditCoursePage.propTypes = {
   courseInfo: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   courseOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   courseRunOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   fetchCourseInfo: PropTypes.func,

--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -131,7 +131,7 @@ BaseStafferForm.propTypes = {
   pristine: PropTypes.bool.isRequired,
   stafferOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   isSaving: PropTypes.bool,

--- a/src/components/StafferPage/StafferPage.test.jsx
+++ b/src/components/StafferPage/StafferPage.test.jsx
@@ -26,7 +26,7 @@ describe('StafferPage', () => {
       fetchStafferOptions={() => null}
       stafferOptions={{
         data: {},
-        error: 'Fail',
+        error: ['Fail'],
         isFetching: false,
       }}
       stafferInfo={{
@@ -47,7 +47,7 @@ describe('StafferPage', () => {
         isFetching: false,
       }}
       stafferInfo={{
-        error: 'Fail',
+        error: ['Fail'],
         isSaving: false,
       }}
     />);
@@ -60,11 +60,11 @@ describe('StafferPage', () => {
       fetchStafferOptions={() => null}
       stafferOptions={{
         data: {},
-        error: 'Fail',
+        error: ['Fail'],
         isFetching: false,
       }}
       stafferInfo={{
-        error: 'Fail here too',
+        error: ['Fail here too'],
         isSaving: false,
       }}
     />);

--- a/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferPage.test.jsx.snap
@@ -56,7 +56,6 @@ ShallowWrapper {
               stafferInfo={Object {}}
               stafferOptions={Object {}}
             />
-            
           </div>
         </PageContainer>,
       ],
@@ -112,7 +111,6 @@ ShallowWrapper {
                 stafferInfo={Object {}}
                 stafferOptions={Object {}}
               />
-              
             </div>,
           ],
           "className": "",
@@ -144,7 +142,7 @@ ShallowWrapper {
                   stafferInfo={Object {}}
                   stafferOptions={Object {}}
                 />,
-                "",
+                false,
               ],
             },
             "ref": null,
@@ -192,7 +190,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              "",
+              false,
             ],
             "type": "div",
           },
@@ -238,7 +236,6 @@ ShallowWrapper {
                 stafferInfo={Object {}}
                 stafferOptions={Object {}}
               />
-              
             </div>
           </PageContainer>,
         ],
@@ -294,7 +291,6 @@ ShallowWrapper {
                   stafferInfo={Object {}}
                   stafferOptions={Object {}}
                 />
-                
               </div>,
             ],
             "className": "",
@@ -326,7 +322,7 @@ ShallowWrapper {
                     stafferInfo={Object {}}
                     stafferOptions={Object {}}
                   />,
-                  "",
+                  false,
                 ],
               },
               "ref": null,
@@ -374,7 +370,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                "",
+                false,
               ],
               "type": "div",
             },
@@ -486,7 +482,6 @@ ShallowWrapper {
               stafferInfo={Object {}}
               stafferOptions={Object {}}
             />
-            
           </div>
         </PageContainer>,
       ],
@@ -556,7 +551,6 @@ ShallowWrapper {
                 stafferInfo={Object {}}
                 stafferOptions={Object {}}
               />
-              
             </div>,
           ],
           "className": "",
@@ -601,7 +595,7 @@ ShallowWrapper {
                   stafferInfo={Object {}}
                   stafferOptions={Object {}}
                 />,
-                "",
+                false,
               ],
             },
             "ref": null,
@@ -668,7 +662,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              "",
+              false,
             ],
             "type": "div",
           },
@@ -728,7 +722,6 @@ ShallowWrapper {
                 stafferInfo={Object {}}
                 stafferOptions={Object {}}
               />
-              
             </div>
           </PageContainer>,
         ],
@@ -798,7 +791,6 @@ ShallowWrapper {
                   stafferInfo={Object {}}
                   stafferOptions={Object {}}
                 />
-                
               </div>,
             ],
             "className": "",
@@ -843,7 +835,7 @@ ShallowWrapper {
                     stafferInfo={Object {}}
                     stafferOptions={Object {}}
                   />,
-                  "",
+                  false,
                 ],
               },
               "ref": null,
@@ -910,7 +902,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                "",
+                false,
               ],
               "type": "div",
             },
@@ -1027,7 +1019,6 @@ ShallowWrapper {
                 }
               }
             />
-            
           </div>
         </PageContainer>,
       ],
@@ -1095,7 +1086,6 @@ ShallowWrapper {
                   }
                 }
               />
-              
             </div>,
           ],
           "className": "",
@@ -1139,7 +1129,7 @@ ShallowWrapper {
                     }
                   }
                 />,
-                "",
+                false,
               ],
             },
             "ref": null,
@@ -1194,7 +1184,7 @@ ShallowWrapper {
                 "rendered": null,
                 "type": [Function],
               },
-              "",
+              false,
             ],
             "type": "div",
           },
@@ -1252,7 +1242,6 @@ ShallowWrapper {
                   }
                 }
               />
-              
             </div>
           </PageContainer>,
         ],
@@ -1320,7 +1309,6 @@ ShallowWrapper {
                     }
                   }
                 />
-                
               </div>,
             ],
             "className": "",
@@ -1364,7 +1352,7 @@ ShallowWrapper {
                       }
                     }
                   />,
-                  "",
+                  false,
                 ],
               },
               "ref": null,
@@ -1419,7 +1407,7 @@ ShallowWrapper {
                   "rendered": null,
                   "type": [Function],
                 },
-                "",
+                false,
               ],
               "type": "div",
             },
@@ -1882,7 +1870,9 @@ ShallowWrapper {
     sourceInfo={Object {}}
     stafferInfo={
       Object {
-        "error": "Fail",
+        "error": Array [
+          "Fail",
+        ],
         "isSaving": false,
       }
     }
@@ -1938,7 +1928,9 @@ ShallowWrapper {
               sourceInfo={Object {}}
               stafferInfo={
                 Object {
-                  "error": "Fail",
+                  "error": Array [
+                    "Fail",
+                  ],
                   "isSaving": false,
                 }
               }
@@ -1956,7 +1948,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
-              message="Fail"
+              message={
+                Array [
+                  "Fail",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -2015,7 +2012,9 @@ ShallowWrapper {
                 sourceInfo={Object {}}
                 stafferInfo={
                   Object {
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isSaving": false,
                   }
                 }
@@ -2033,7 +2032,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -2068,7 +2072,9 @@ ShallowWrapper {
                   sourceInfo={Object {}}
                   stafferInfo={
                     Object {
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isSaving": false,
                     }
                   }
@@ -2086,7 +2092,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />,
@@ -2131,7 +2142,9 @@ ShallowWrapper {
                   "onSubmit": [Function],
                   "sourceInfo": Object {},
                   "stafferInfo": Object {
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isSaving": false,
                   },
                   "stafferOptions": Object {
@@ -2154,7 +2167,10 @@ ShallowWrapper {
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
-                  "message": "Fail",
+                  "message": Array [
+                    "Fail",
+                    <br />,
+                  ],
                   "onClose": [Function],
                   "title": null,
                 },
@@ -2207,7 +2223,9 @@ ShallowWrapper {
                 sourceInfo={Object {}}
                 stafferInfo={
                   Object {
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isSaving": false,
                   }
                 }
@@ -2225,7 +2243,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -2284,7 +2307,9 @@ ShallowWrapper {
                   sourceInfo={Object {}}
                   stafferInfo={
                     Object {
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isSaving": false,
                     }
                   }
@@ -2302,7 +2327,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />
@@ -2337,7 +2367,9 @@ ShallowWrapper {
                     sourceInfo={Object {}}
                     stafferInfo={
                       Object {
-                        "error": "Fail",
+                        "error": Array [
+                          "Fail",
+                        ],
                         "isSaving": false,
                       }
                     }
@@ -2355,7 +2387,12 @@ ShallowWrapper {
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
-                    message="Fail"
+                    message={
+                      Array [
+                        "Fail",
+                        <br />,
+                      ]
+                    }
                     onClose={[Function]}
                     title={null}
                   />,
@@ -2400,7 +2437,9 @@ ShallowWrapper {
                     "onSubmit": [Function],
                     "sourceInfo": Object {},
                     "stafferInfo": Object {
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isSaving": false,
                     },
                     "stafferOptions": Object {
@@ -2423,7 +2462,10 @@ ShallowWrapper {
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",
-                    "message": "Fail",
+                    "message": Array [
+                      "Fail",
+                      <br />,
+                    ],
                     "onClose": [Function],
                     "title": null,
                   },
@@ -2479,14 +2521,18 @@ ShallowWrapper {
     sourceInfo={Object {}}
     stafferInfo={
       Object {
-        "error": "Fail here too",
+        "error": Array [
+          "Fail here too",
+        ],
         "isSaving": false,
       }
     }
     stafferOptions={
       Object {
         "data": Object {},
-        "error": "Fail",
+        "error": Array [
+          "Fail",
+        ],
         "isFetching": false,
       }
     }
@@ -2535,14 +2581,18 @@ ShallowWrapper {
               sourceInfo={Object {}}
               stafferInfo={
                 Object {
-                  "error": "Fail here too",
+                  "error": Array [
+                    "Fail here too",
+                  ],
                   "isSaving": false,
                 }
               }
               stafferOptions={
                 Object {
                   "data": Object {},
-                  "error": "Fail",
+                  "error": Array [
+                    "Fail",
+                  ],
                   "isFetching": false,
                 }
               }
@@ -2553,7 +2603,14 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
-              message="Fail here too Fail"
+              message={
+                Array [
+                  "Fail here too",
+                  <br />,
+                  "Fail",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -2612,14 +2669,18 @@ ShallowWrapper {
                 sourceInfo={Object {}}
                 stafferInfo={
                   Object {
-                    "error": "Fail here too",
+                    "error": Array [
+                      "Fail here too",
+                    ],
                     "isSaving": false,
                   }
                 }
                 stafferOptions={
                   Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   }
                 }
@@ -2630,7 +2691,14 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail here too Fail"
+                message={
+                  Array [
+                    "Fail here too",
+                    <br />,
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -2665,14 +2733,18 @@ ShallowWrapper {
                   sourceInfo={Object {}}
                   stafferInfo={
                     Object {
-                      "error": "Fail here too",
+                      "error": Array [
+                        "Fail here too",
+                      ],
                       "isSaving": false,
                     }
                   }
                   stafferOptions={
                     Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     }
                   }
@@ -2683,7 +2755,14 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail here too Fail"
+                  message={
+                    Array [
+                      "Fail here too",
+                      <br />,
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />,
@@ -2728,12 +2807,16 @@ ShallowWrapper {
                   "onSubmit": [Function],
                   "sourceInfo": Object {},
                   "stafferInfo": Object {
-                    "error": "Fail here too",
+                    "error": Array [
+                      "Fail here too",
+                    ],
                     "isSaving": false,
                   },
                   "stafferOptions": Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   },
                 },
@@ -2751,7 +2834,12 @@ ShallowWrapper {
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
-                  "message": "Fail here too Fail",
+                  "message": Array [
+                    "Fail here too",
+                    <br />,
+                    "Fail",
+                    <br />,
+                  ],
                   "onClose": [Function],
                   "title": null,
                 },
@@ -2804,14 +2892,18 @@ ShallowWrapper {
                 sourceInfo={Object {}}
                 stafferInfo={
                   Object {
-                    "error": "Fail here too",
+                    "error": Array [
+                      "Fail here too",
+                    ],
                     "isSaving": false,
                   }
                 }
                 stafferOptions={
                   Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   }
                 }
@@ -2822,7 +2914,14 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail here too Fail"
+                message={
+                  Array [
+                    "Fail here too",
+                    <br />,
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -2881,14 +2980,18 @@ ShallowWrapper {
                   sourceInfo={Object {}}
                   stafferInfo={
                     Object {
-                      "error": "Fail here too",
+                      "error": Array [
+                        "Fail here too",
+                      ],
                       "isSaving": false,
                     }
                   }
                   stafferOptions={
                     Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     }
                   }
@@ -2899,7 +3002,14 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail here too Fail"
+                  message={
+                    Array [
+                      "Fail here too",
+                      <br />,
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />
@@ -2934,14 +3044,18 @@ ShallowWrapper {
                     sourceInfo={Object {}}
                     stafferInfo={
                       Object {
-                        "error": "Fail here too",
+                        "error": Array [
+                          "Fail here too",
+                        ],
                         "isSaving": false,
                       }
                     }
                     stafferOptions={
                       Object {
                         "data": Object {},
-                        "error": "Fail",
+                        "error": Array [
+                          "Fail",
+                        ],
                         "isFetching": false,
                       }
                     }
@@ -2952,7 +3066,14 @@ ShallowWrapper {
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
-                    message="Fail here too Fail"
+                    message={
+                      Array [
+                        "Fail here too",
+                        <br />,
+                        "Fail",
+                        <br />,
+                      ]
+                    }
                     onClose={[Function]}
                     title={null}
                   />,
@@ -2997,12 +3118,16 @@ ShallowWrapper {
                     "onSubmit": [Function],
                     "sourceInfo": Object {},
                     "stafferInfo": Object {
-                      "error": "Fail here too",
+                      "error": Array [
+                        "Fail here too",
+                      ],
                       "isSaving": false,
                     },
                     "stafferOptions": Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     },
                   },
@@ -3020,7 +3145,12 @@ ShallowWrapper {
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",
-                    "message": "Fail here too Fail",
+                    "message": Array [
+                      "Fail here too",
+                      <br />,
+                      "Fail",
+                      <br />,
+                    ],
                     "onClose": [Function],
                     "title": null,
                   },
@@ -3083,7 +3213,9 @@ ShallowWrapper {
     stafferOptions={
       Object {
         "data": Object {},
-        "error": "Fail",
+        "error": Array [
+          "Fail",
+        ],
         "isFetching": false,
       }
     }
@@ -3139,7 +3271,9 @@ ShallowWrapper {
               stafferOptions={
                 Object {
                   "data": Object {},
-                  "error": "Fail",
+                  "error": Array [
+                    "Fail",
+                  ],
                   "isFetching": false,
                 }
               }
@@ -3150,7 +3284,12 @@ ShallowWrapper {
               dismissible={false}
               iconClassNames={Array []}
               id="create-staffer-error"
-              message="Fail"
+              message={
+                Array [
+                  "Fail",
+                  <br />,
+                ]
+              }
               onClose={[Function]}
               title={null}
             />
@@ -3216,7 +3355,9 @@ ShallowWrapper {
                 stafferOptions={
                   Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   }
                 }
@@ -3227,7 +3368,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -3269,7 +3415,9 @@ ShallowWrapper {
                   stafferOptions={
                     Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     }
                   }
@@ -3280,7 +3428,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />,
@@ -3330,7 +3483,9 @@ ShallowWrapper {
                   },
                   "stafferOptions": Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   },
                 },
@@ -3348,7 +3503,10 @@ ShallowWrapper {
                   "dismissible": false,
                   "iconClassNames": Array [],
                   "id": "create-staffer-error",
-                  "message": "Fail",
+                  "message": Array [
+                    "Fail",
+                    <br />,
+                  ],
                   "onClose": [Function],
                   "title": null,
                 },
@@ -3408,7 +3566,9 @@ ShallowWrapper {
                 stafferOptions={
                   Object {
                     "data": Object {},
-                    "error": "Fail",
+                    "error": Array [
+                      "Fail",
+                    ],
                     "isFetching": false,
                   }
                 }
@@ -3419,7 +3579,12 @@ ShallowWrapper {
                 dismissible={false}
                 iconClassNames={Array []}
                 id="create-staffer-error"
-                message="Fail"
+                message={
+                  Array [
+                    "Fail",
+                    <br />,
+                  ]
+                }
                 onClose={[Function]}
                 title={null}
               />
@@ -3485,7 +3650,9 @@ ShallowWrapper {
                   stafferOptions={
                     Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     }
                   }
@@ -3496,7 +3663,12 @@ ShallowWrapper {
                   dismissible={false}
                   iconClassNames={Array []}
                   id="create-staffer-error"
-                  message="Fail"
+                  message={
+                    Array [
+                      "Fail",
+                      <br />,
+                    ]
+                  }
                   onClose={[Function]}
                   title={null}
                 />
@@ -3538,7 +3710,9 @@ ShallowWrapper {
                     stafferOptions={
                       Object {
                         "data": Object {},
-                        "error": "Fail",
+                        "error": Array [
+                          "Fail",
+                        ],
                         "isFetching": false,
                       }
                     }
@@ -3549,7 +3723,12 @@ ShallowWrapper {
                     dismissible={false}
                     iconClassNames={Array []}
                     id="create-staffer-error"
-                    message="Fail"
+                    message={
+                      Array [
+                        "Fail",
+                        <br />,
+                      ]
+                    }
                     onClose={[Function]}
                     title={null}
                   />,
@@ -3599,7 +3778,9 @@ ShallowWrapper {
                     },
                     "stafferOptions": Object {
                       "data": Object {},
-                      "error": "Fail",
+                      "error": Array [
+                        "Fail",
+                      ],
                       "isFetching": false,
                     },
                   },
@@ -3617,7 +3798,10 @@ ShallowWrapper {
                     "dismissible": false,
                     "iconClassNames": Array [],
                     "id": "create-staffer-error",
-                    "message": "Fail",
+                    "message": Array [
+                      "Fail",
+                      <br />,
+                    ],
                     "onClose": [Function],
                     "title": null,
                   },

--- a/src/components/StafferPage/index.jsx
+++ b/src/components/StafferPage/index.jsx
@@ -129,15 +129,25 @@ class StafferPage extends React.Component {
 
     const { data, isSaving } = stafferInfo;
 
-    let error = '';
-    if (stafferInfo.error) {
-      error = error.concat(stafferInfo.error, ' ');
-    }
-    if (stafferOptions.error) {
-      error = error.concat(stafferOptions.error);
-    }
-    error = error.trim();
+    const errorArray = [];
 
+    if (stafferInfo.error) {
+      stafferInfo.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < stafferInfo.error.length) {
+          errorArray.push(<br />);
+        }
+      });
+    }
+
+    if (stafferOptions.error) {
+      stafferOptions.error.forEach((error, index) => {
+        errorArray.push(error);
+        if (index < stafferOptions.error.length) {
+          errorArray.push(<br />);
+        }
+      });
+    }
     const { referrer } = sourceInfo;
 
     return (
@@ -167,11 +177,11 @@ class StafferPage extends React.Component {
                 initialValues={data}
                 {...this.props}
               />
-              { error && (
+              { errorArray.length > 1 && (
                 <StatusAlert
                   id="create-staffer-error"
                   alertType="danger"
-                  message={error}
+                  message={errorArray}
                 />
               )}
             </div>
@@ -199,14 +209,14 @@ StafferPage.propTypes = {
   fetchStafferInfo: PropTypes.func,
   stafferOptions: PropTypes.shape({
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
     isFetching: PropTypes.bool,
   }),
   stafferInfo: PropTypes.shape({
     isFetching: PropTypes.bool,
     isSaving: PropTypes.bool,
     data: PropTypes.shape(),
-    error: PropTypes.string,
+    error: PropTypes.arrayOf(PropTypes.string),
   }),
   sourceInfo: PropTypes.shape({
     referrer: PropTypes.string,

--- a/src/components/StatusAlert/index.jsx
+++ b/src/components/StatusAlert/index.jsx
@@ -46,7 +46,9 @@ const StatusAlert = (props) => {
 
 StatusAlert.propTypes = {
   alertType: PropTypes.string.isRequired,
-  message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  message: PropTypes.oneOfType([
+    PropTypes.string, PropTypes.element, PropTypes.array,
+  ]).isRequired,
   className: PropTypes.string,
   iconClassNames: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,

--- a/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
+++ b/src/components/TableComponent/__snapshots__/TableComponent.test.jsx.snap
@@ -2350,7 +2350,12 @@ ShallowWrapper {
               "fa-times-circle",
             ]
           }
-          message="Unable to load data: Test error."
+          message={
+            Array [
+              "Unable to load data",
+              "Test error.",
+            ]
+          }
           onClose={[Function]}
           title={null}
         />,
@@ -2373,7 +2378,10 @@ ShallowWrapper {
             "fa",
             "fa-times-circle",
           ],
-          "message": "Unable to load data: Test error.",
+          "message": Array [
+            "Unable to load data",
+            "Test error.",
+          ],
           "onClose": [Function],
           "title": null,
         },
@@ -2404,7 +2412,12 @@ ShallowWrapper {
                 "fa-times-circle",
               ]
             }
-            message="Unable to load data: Test error."
+            message={
+              Array [
+                "Unable to load data",
+                "Test error.",
+              ]
+            }
             onClose={[Function]}
             title={null}
           />,
@@ -2427,7 +2440,10 @@ ShallowWrapper {
               "fa",
               "fa-times-circle",
             ],
-            "message": "Unable to load data: Test error.",
+            "message": Array [
+              "Unable to load data",
+              "Test error.",
+            ],
             "onClose": [Function],
             "title": null,
           },

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -7,7 +7,7 @@ import 'font-awesome/css/font-awesome.css';
 
 import LoadingSpinner from '../LoadingSpinner';
 import StatusAlert from '../StatusAlert';
-import { getErrorMessage, updateUrl } from '../../utils';
+import { getErrorMessages, updateUrl } from '../../utils';
 
 class TableComponent extends React.Component {
   componentDidMount() {
@@ -100,7 +100,7 @@ class TableComponent extends React.Component {
       <StatusAlert
         alertType="danger"
         iconClassNames={['fa', 'fa-times-circle']}
-        message={`Unable to load data: ${getErrorMessage(this.props.error)}.`}
+        message={['Unable to load data'].concat(getErrorMessages(this.props.error))}
       />
     );
   }

--- a/src/containers/CreateCourse/CreateCourse.test.jsx
+++ b/src/containers/CreateCourse/CreateCourse.test.jsx
@@ -52,12 +52,12 @@ describe('Create Course View', () => {
 
   it('shows error when fails to retrieve organizations', () => {
     const testState = jsonDeepCopy(initialState);
-    const errorMessage = 'organization failure';
+    const errorMessage = ['organization failure'];
     testState.publisherUserInfo.isFetching = false;
     testState.publisherUserInfo.error = errorMessage;
     const wrapper = createWrapper(testState).dive();
-    expect(wrapper.find('#user-info-error')).toHaveLength(1);
-    expect(wrapper.find('#user-info-error').props().message).toEqual(errorMessage);
+    expect(wrapper.find('#create-error')).toHaveLength(1);
+    expect(wrapper.find('#create-error').props().message).toEqual(errorMessage.concat(<br />));
   });
 
   it('Submits the form with correct data', () => {

--- a/src/data/actions/courseInfo.js
+++ b/src/data/actions/courseInfo.js
@@ -1,6 +1,6 @@
 import { push } from 'connected-react-router';
 
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 import {
   REQUEST_COURSE_INFO_FAIL,
@@ -72,7 +72,7 @@ function fetchCourseInfo(id) {
   return (dispatch) => {
     // We only support UUIDs right now, not course keys
     if (!UUID_REGEX.test(id)) {
-      const error = `Could not get course information. ${id} is not a valid course UUID.`;
+      const error = [`Could not get course information. ${id} is not a valid course UUID.`];
       dispatch(requestCourseInfoFail(id, error));
       return Promise.resolve(); // early exit with empty promise
     }
@@ -87,7 +87,7 @@ function fetchCourseInfo(id) {
       .catch((error) => {
         dispatch(requestCourseInfoFail(
           id,
-          `Could not get course information. ${getErrorMessage(error)}.`,
+          ['Could not get course information.'].concat(getErrorMessages(error)),
         ));
       });
   };
@@ -97,7 +97,7 @@ function createCourseRun(course, courseRunData) {
   return (dispatch) => {
     dispatch(createNewCourseRun());
     if (!course.key) {
-      dispatch(createCourseRunFail('Course Run create failed, please try again or contact support. Course create incomplete.'));
+      dispatch(createCourseRunFail(['Course Run create failed, please try again or contact support. Course create incomplete.']));
       return null;
     }
 
@@ -113,7 +113,7 @@ function createCourseRun(course, courseRunData) {
         return dispatch(push(`/courses/${course.uuid}/edit/`));
       })
       .catch((error) => {
-        dispatch(createCourseRunFail(`Course Run create failed, please try again or contact support. ${getErrorMessage(error)}.`));
+        dispatch(createCourseRunFail(['Course Run create failed, please try again or contact support.'].concat(getErrorMessages(error))));
       });
   };
 }
@@ -129,7 +129,7 @@ function createCourse(courseData, courseRunData) {
         dispatch(createCourseRun(course, courseRunData));
       })
       .catch((error) => {
-        dispatch(createCourseFail(`Course create failed, please try again or contact support. ${getErrorMessage(error)}.`));
+        dispatch(createCourseFail(['Course create failed, please try again or contact support.'].concat(getErrorMessages(error))));
       });
   };
 }
@@ -145,7 +145,7 @@ function editCourse(courseData, courseRunData) {
         dispatch(editCourseSuccess(course));
       })
       .catch((error) => {
-        dispatch(editCourseFail(`Course edit failed, please try again or contact support. ${getErrorMessage(error)}.`));
+        dispatch(editCourseFail(['Course edit failed, please try again or contact support.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/courseInfo.test.js
+++ b/src/data/actions/courseInfo.test.js
@@ -58,7 +58,7 @@ describe('courseInfo fetch course actions', () => {
       requestCourseInfo(uuid),
       requestCourseInfoFail(
         uuid,
-        'Could not get course information. Request failed with status code 500.',
+        ['Could not get course information.', 'Request failed with status code 500.'],
       ),
     ];
     const store = mockStore();
@@ -72,7 +72,7 @@ describe('courseInfo fetch course actions', () => {
     const expectedActions = [
       requestCourseInfoFail(
         'test',
-        'Could not get course information. test is not a valid course UUID.',
+        ['Could not get course information. test is not a valid course UUID.'],
       ),
     ];
     const store = mockStore();

--- a/src/data/actions/courseOptions.js
+++ b/src/data/actions/courseOptions.js
@@ -6,7 +6,7 @@ import {
 
 import { UUID_REGEX } from '../constants/courseInfo';
 
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
 
@@ -28,7 +28,7 @@ function fetchCourseOptions(id) {
     // We only support UUIDs right now, not course keys
     if (!UUID_REGEX.test(id)) {
       const error = `Could not get course information. ${id} is not a valid course UUID.`;
-      dispatch(requestCourseOptionsFail(id, getErrorMessage(error)));
+      dispatch(requestCourseOptionsFail(id, [error]));
       return Promise.resolve(); // early exit with empty promise
     }
 
@@ -40,7 +40,7 @@ function fetchCourseOptions(id) {
 
         // Confirm it looks vaguely correct
         if (!course || !('actions' in course)) {
-          throw Error('Did not understand response');
+          throw Error('Did not understand response.');
         }
 
         dispatch(requestCourseOptionsSuccess(id, course));
@@ -48,7 +48,7 @@ function fetchCourseOptions(id) {
       .catch((error) => {
         dispatch(requestCourseOptionsFail(
           id,
-          `Could not get course information. ${getErrorMessage(error)}.`,
+          ['Could not get course information.'].concat(getErrorMessages(error)),
         ));
       });
   };

--- a/src/data/actions/courseOptions.test.js
+++ b/src/data/actions/courseOptions.test.js
@@ -91,7 +91,7 @@ describe('courseOptions fetch course actions', () => {
       requestCourseOptions(uuid),
       requestCourseOptionsFail(
         uuid,
-        'Could not get course information. Request failed with status code 500.',
+        ['Could not get course information.', 'Request failed with status code 500.'],
       ),
     ];
     const store = mockStore();
@@ -105,7 +105,7 @@ describe('courseOptions fetch course actions', () => {
     const expectedActions = [
       requestCourseOptionsFail(
         'test',
-        'Could not get course information. test is not a valid course UUID.',
+        ['Could not get course information. test is not a valid course UUID.'],
       ),
     ];
     const store = mockStore();
@@ -123,7 +123,7 @@ describe('courseOptions fetch course actions', () => {
       requestCourseOptions(uuid),
       requestCourseOptionsFail(
         uuid,
-        'Could not get course information. Did not understand response.',
+        ['Could not get course information.', 'Did not understand response.'],
       ),
     ];
     const store = mockStore();

--- a/src/data/actions/courseRunOptions.js
+++ b/src/data/actions/courseRunOptions.js
@@ -5,7 +5,7 @@ import {
 } from '../constants/courseRunOptions';
 
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 function requestCourseRunOptionsFail(error) {
   return { type: REQUEST_COURSE_RUN_OPTIONS_FAIL, error };
@@ -29,13 +29,13 @@ function fetchCourseRunOptions() {
 
         // Confirm it looks vaguely correct
         if (!courseRun || !('actions' in courseRun)) {
-          throw Error('Did not understand response');
+          throw Error('Did not understand response.');
         }
 
         dispatch(requestCourseRunOptionsSuccess(courseRun));
       })
       .catch((error) => {
-        dispatch(requestCourseRunOptionsFail(`Could not get course run information. ${getErrorMessage(error)}.`));
+        dispatch(requestCourseRunOptionsFail(['Could not get course run information.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/courseRunOptions.test.js
+++ b/src/data/actions/courseRunOptions.test.js
@@ -482,7 +482,7 @@ describe('courseRunOptions fetch courseRun actions', () => {
 
     const expectedActions = [
       requestCourseRunOptions(),
-      requestCourseRunOptionsFail('Could not get course run information. Request failed with status code 500.'),
+      requestCourseRunOptionsFail(['Could not get course run information.', 'Request failed with status code 500.']),
     ];
     const store = mockStore();
 
@@ -497,7 +497,7 @@ describe('courseRunOptions fetch courseRun actions', () => {
 
     const expectedActions = [
       requestCourseRunOptions(),
-      requestCourseRunOptionsFail('Could not get course run information. Did not understand response.'),
+      requestCourseRunOptionsFail(['Could not get course run information.', 'Did not understand response.']),
     ];
     const store = mockStore();
 

--- a/src/data/actions/publisherUserInfo.js
+++ b/src/data/actions/publisherUserInfo.js
@@ -6,7 +6,7 @@ import {
 
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
 
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 function requestUserOrganizationsFail(error) {
   return { type: REQUEST_USER_ORGANIZATIONS_FAIL, error };
@@ -30,7 +30,7 @@ function fetchOrganizations() {
         dispatch(requestUserOrganizationsSuccess(organizations));
       })
       .catch((error) => {
-        dispatch(requestUserOrganizationsFail(`Unable to retrieve user Organizations, please contact support: ${getErrorMessage(error)}.`));
+        dispatch(requestUserOrganizationsFail(['Unable to retrieve user Organizations, please contact support.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/publisherUserInfo.test.js
+++ b/src/data/actions/publisherUserInfo.test.js
@@ -6,7 +6,7 @@ import apiClient from '../apiClient';
 import * as types from '../constants/publisherUserInfo';
 import * as actions from './publisherUserInfo';
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 const mockStore = configureMockStore([thunk]);
 const mockClient = new MockAdapter(apiClient);
@@ -74,7 +74,7 @@ describe('publisherUserInfo fetch organizations actions', () => {
     const url = `${DiscoveryDataApiService.discoveryBaseUrl}/organizations/`;
 
     const error = 'Request failed with status code 404';
-    const expectedError = `Unable to retrieve user Organizations, please contact support: ${getErrorMessage(error)}.`;
+    const expectedError = ['Unable to retrieve user Organizations, please contact support.'].concat(getErrorMessages(error));
     mockClient.onGet(url).replyOnce(404);
 
     const expectedActions = [

--- a/src/data/actions/stafferInfo.js
+++ b/src/data/actions/stafferInfo.js
@@ -12,7 +12,7 @@ import {
   EDIT_STAFFER_INFO_FAIL,
 } from '../constants/stafferInfo';
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 export function createNewStaffer(stafferData) {
   return { type: CREATE_STAFFER, stafferData };
@@ -41,7 +41,7 @@ export function createStaffer(stafferData, referrer = null) {
         }
       })
       .catch((error) => {
-        dispatch(stafferCreateFail(`Instructor create failed, please try again or contact support. ${getErrorMessage(error)}.`));
+        dispatch(stafferCreateFail(['Instructor create failed, please try again or contact support.'].concat(getErrorMessages(error))));
       });
   };
 }
@@ -68,13 +68,13 @@ export function fetchStafferInfo(uuid) {
 
         // Confirm it looks vaguely correct
         if (!stafferInfo || !('family_name' in stafferInfo)) {
-          throw Error('Did not understand response');
+          throw Error('Did not understand response.');
         }
 
         dispatch(requestStafferInfoSuccess(stafferInfo));
       })
       .catch((error) => {
-        dispatch(requestStafferInfoFail(`Could not get instructor information. ${getErrorMessage(error)}.`));
+        dispatch(requestStafferInfoFail(['Could not get instructor information.'].concat(getErrorMessages(error))));
       });
   };
 }
@@ -106,7 +106,7 @@ export function editStaffer(stafferData, referrer = null) {
         }
       })
       .catch((error) => {
-        dispatch(editStafferInfoFail(`Edit instructor failed, please try again or contact support. ${getErrorMessage(error)}.`));
+        dispatch(editStafferInfoFail(['Edit instructor failed, please try again or contact support.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/stafferOptions.js
+++ b/src/data/actions/stafferOptions.js
@@ -5,7 +5,7 @@ import {
 } from '../constants/stafferOptions';
 
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
-import { getErrorMessage } from '../../utils';
+import { getErrorMessages } from '../../utils';
 
 
 function requestStafferOptionsFail(error) {
@@ -30,13 +30,13 @@ function fetchStafferOptions() {
 
         // Confirm it looks vaguely correct
         if (!stafferOptions || !('actions' in stafferOptions)) {
-          throw Error('Did not understand response');
+          throw Error('Did not understand response.');
         }
 
         dispatch(requestStafferOptionsSuccess(stafferOptions));
       })
       .catch((error) => {
-        dispatch(requestStafferOptionsFail(`Could not get instructor information. ${getErrorMessage(error)}.`));
+        dispatch(requestStafferOptionsFail(['Could not get instructor information.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/stafferOptions.test.js
+++ b/src/data/actions/stafferOptions.test.js
@@ -60,7 +60,7 @@ describe('stafferOptions fetch staffer options actions', () => {
 
     const expectedActions = [
       requestStafferOptions(),
-      requestStafferOptionsFail('Could not get instructor information. Request failed with status code 500.'),
+      requestStafferOptionsFail(['Could not get instructor information.', 'Request failed with status code 500.']),
     ];
     const store = mockStore();
 
@@ -74,7 +74,7 @@ describe('stafferOptions fetch staffer options actions', () => {
 
     const expectedActions = [
       requestStafferOptions(),
-      requestStafferOptionsFail('Could not get instructor information. Did not understand response.'),
+      requestStafferOptionsFail(['Could not get instructor information.', 'Did not understand response.']),
     ];
     const store = mockStore();
 

--- a/src/data/reducers/courseInfo.js
+++ b/src/data/reducers/courseInfo.js
@@ -49,6 +49,7 @@ function courseInfo(state = initialState, action) {
     case CREATE_COURSE_SUCCESS:
       return Object.assign({}, state, {
         data: action.data,
+        error: null,
       });
     case CREATE_COURSE_FAIL:
       return Object.assign({}, state, {
@@ -77,6 +78,7 @@ function courseInfo(state = initialState, action) {
     case EDIT_COURSE_SUCCESS:
       return Object.assign({}, state, {
         data: action.data,
+        error: null,
       });
     case EDIT_COURSE_FAIL:
       return Object.assign({}, state, {

--- a/src/data/reducers/table.js
+++ b/src/data/reducers/table.js
@@ -29,6 +29,7 @@ const tableReducer = (state = {}, action) => {
     case PAGINATION_SUCCESS:
       return updateTable(state, action.payload.tableId, {
         loading: false,
+        error: null,
         ordering: action.payload.ordering,
         page: action.payload.page,
         pageSize: action.payload.pageSize,

--- a/src/data/reducers/table.test.js
+++ b/src/data/reducers/table.test.js
@@ -72,7 +72,7 @@ describe('table reducer', () => {
         ordering: newOrdering,
         pageSize: newPageSize,
         data: newData,
-        error: initialState[tableId].error,
+        error: null,
       },
     });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,18 +54,33 @@ const getCourseNumber = (courseKeyFragment) => {
   return keyParts[keyParts.length - 1];
 };
 
-const getErrorMessage = (error) => {
+const addPeriodToString = (string) => {
+  if (typeof string === 'string') {
+    const punctuation = new Set(['.', ',', ':', '!', '?']);
+    if (punctuation.has(string.substr(-1))) {
+      return string;
+    }
+    return `${string}.`;
+  }
+  return string;
+};
+
+const getErrorMessages = (error) => {
   if (typeof error === 'object') {
     // For form validation from DRF, comes back as an object of fields:errors
-    if (error.response && error.response.data && typeof data === 'object') {
-      return Object.keys(error.response.data).map(key => `${key}: ${error.response.data[key]}`);
+    if (error.response && error.response.data && typeof error.response.data === 'object') {
+      return Object.keys(error.response.data).map(key => addPeriodToString(`${key}: ${error.response.data[key]}`));
     }
-    // For base JS errors check .message first before checking the response
-    return error.message || error.response.data || error.response.message;
+    // Some request responses contain a .message, as well as JS errors let's
+    // try to use the request data or message before the or base JS errors check
+    const message = (
+      error.response && (error.response.data || error.response.message)
+    ) || error.message || error;
+    return [addPeriodToString(message)];
   } else if (typeof error === 'string') {
-    return error;
+    return [addPeriodToString(error)];
   }
-  return null;
+  return ['Unknown error.'];
 };
 
 export {
@@ -73,5 +88,5 @@ export {
   getPageOptionsFromUrl,
   jsonDeepCopy,
   getCourseNumber,
-  getErrorMessage,
+  getErrorMessages,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -21,3 +21,48 @@ describe('getCourseNumber', () => {
     expect(utils.getCourseNumber(courseKeyFragmentOld)).toEqual(expected);
   });
 });
+
+describe('getCourseError', () => {
+  it('returns a string from a string', () => {
+    const testError = 'Test error message';
+    expect(utils.getErrorMessages(testError)).toEqual(['Test error message.']);
+  });
+
+  it('returns a string from a JS error', () => {
+    const testError = new Error('Test error message');
+    expect(utils.getErrorMessages(testError)).toEqual(['Test error message.']);
+  });
+
+  it('returns an array of strings from a DRF-like error ', () => {
+    const testResponse = {
+      response: {
+        data: {
+          key: 'value',
+        },
+        message: 'Response message',
+      },
+      message: 'Error message',
+    };
+    expect(utils.getErrorMessages(testResponse)).toEqual(['key: value.']);
+  });
+
+  it('returns a string from an error without data', () => {
+    const testResponse = {
+      response: {
+        message: 'Response message',
+      },
+      message: 'Error message',
+    };
+    expect(utils.getErrorMessages(testResponse)).toEqual(['Response message.']);
+  });
+
+  it('returns the object if fields not found for an object', () => {
+    const testResponse = {};
+    expect(utils.getErrorMessages(testResponse)).toEqual([{}]);
+  });
+
+  it('returns an error message if type is not known', () => {
+    const testResponse = 10; // Just a random integer
+    expect(utils.getErrorMessages(testResponse)).toEqual(['Unknown error.']);
+  });
+});


### PR DESCRIPTION
Adds in a helper method to try and parse our different error soruces. Swaps all redux action failures to take in an array of strings for error messaging, then transforms them inside of the pages to include `<br />` tags. Also fixes the persistent error between page changes for certain success/info cases where `error: null` wasn't set.