### PR TITLE
Fix course status pill for when there are incomplete runs

### DIFF
--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -200,7 +200,7 @@ class EditCoursePage extends React.Component {
       courseStatuses.push(REVIEWED);
     }
     if (course_runs && !courseStatuses.includes(PUBLISHED) &&
-        !courseStatuses.includes(IN_REVIEW_STATUS[0]) && !!courseStatuses.includes(REVIEWED) &&
+        !courseStatuses.includes(IN_REVIEW_STATUS[0]) && !courseStatuses.includes(REVIEWED) &&
         course_runs.some(courseRun => UNPUBLISHED === courseRun.status)) {
       courseStatuses.push(UNPUBLISHED);
     }


### PR DESCRIPTION
Figured out why the incomplete pill wasn't always showing up. Shouldn't be using `!!`