### PR TITLE
Client side validation/focus for non-input fields

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -309,7 +309,6 @@ class CollapsibleCourseRun extends React.Component {
             </div>
           }
         />
-        {/* We don't use pass through props on staff to avoid wiping out meta info */}
         <Field
           name={`${courseId}.staff`}
           component={StaffList}

--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -6,11 +6,13 @@ import { Collapsible } from '@edx/paragon';
 
 import ActionButton from '../ActionButton';
 import ButtonToolbar from '../ButtonToolbar';
+import courseSubmitInfo from '../../data/actions/courseSubmitInfo';
 import FieldLabel from '../FieldLabel';
 import Pill from '../Pill';
 import RenderInputTextField from '../RenderInputTextField';
 import RenderSelectField from '../RenderSelectField';
 import StaffList from '../StaffList';
+import store from '../../data/store';
 import TranscriptLanguage from './TranscriptLanguage';
 
 import { IN_REVIEW_STATUS, PUBLISHED } from '../../data/constants';
@@ -88,12 +90,14 @@ class CollapsibleCourseRun extends React.Component {
       courseInReview,
       courseRun,
       courseSubmitting,
-      handleSubmit,
       isSubmittingForReview,
       languageOptions,
       pacingTypeOptions,
       targetRun,
-      ...passThroughProps
+      owners,
+      courseUuid,
+      stafferInfo,
+      sourceInfo,
     } = this.props;
     const {
       open,
@@ -107,7 +111,6 @@ class CollapsibleCourseRun extends React.Component {
     return (
       <Collapsible
         title={formatCourseRunTitle(courseRun)}
-        key={`collapsible-run-${courseId}`}
         iconId={`collapsible-icon-${courseId}`}
         isOpen={open}
         onToggle={this.setCollapsible}
@@ -270,7 +273,6 @@ class CollapsibleCourseRun extends React.Component {
           languageOptions={languageOptions}
           extraInput={{ onInvalid: this.openCollapsible }}
           disabled={courseInReview}
-          required={courseRunSubmitting}
         />
         <Field
           name={`${courseId}.weeks_to_complete`}
@@ -307,32 +309,29 @@ class CollapsibleCourseRun extends React.Component {
             </div>
           }
         />
+        {/* We don't use pass through props on staff to avoid wiping out meta info */}
         <Field
           name={`${courseId}.staff`}
           component={StaffList}
           extraInput={{ onInvalid: this.openCollapsible }}
           disabled={courseInReview}
           courseRunKey={courseRun.key}
-          required={courseRunSubmitting}
-          {...passThroughProps}
+          owners={owners}
+          courseUuid={courseUuid}
+          sourceInfo={sourceInfo}
+          stafferInfo={stafferInfo}
         />
         <ButtonToolbar>
           <ActionButton
             // only disable if *this run* is in review
             disabled={courseSubmitting || courseRunInReview}
-            onClick={(event) => {
-              /*
-              *  Prevent default submission and pass the targeted course run up through the
-              *  handler to manually validate fields based off the run status.
-              */
-              event.preventDefault();
-              handleSubmit(courseRun);
-            }}
+            // Pass the submitting course run up to validate different fields based on status
+            onClick={() => store.dispatch(courseSubmitInfo(courseRun))}
             labels={{
               default: courseRun.status === PUBLISHED ? 'Publish' : 'Submit for Review',
               pending: courseRun.status === PUBLISHED ? 'Publishing' : 'Submitting for Review',
             }}
-            state={courseRunSubmitting ? 'pending' : 'default'}
+            state={courseSubmitting ? 'pending' : 'default'}
           />
         </ButtonToolbar>
       </Collapsible>
@@ -345,16 +344,19 @@ CollapsibleCourseRun.propTypes = {
   courseInReview: PropTypes.bool,
   courseRun: PropTypes.shape({}).isRequired,
   courseSubmitting: PropTypes.bool,
-  handleSubmit: PropTypes.func.isRequired,
+  courseUuid: PropTypes.string.isRequired,
   isSubmittingForReview: PropTypes.bool,
   languageOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string,
   })).isRequired,
+  owners: PropTypes.arrayOf(PropTypes.shape({})),
   pacingTypeOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
     value: PropTypes.string,
   })).isRequired,
+  sourceInfo: PropTypes.shape({}),
+  stafferInfo: PropTypes.shape({}),
   targetRun: PropTypes.shape({}),
 };
 
@@ -362,6 +364,9 @@ CollapsibleCourseRun.defaultProps = {
   courseInReview: false,
   courseSubmitting: false,
   isSubmittingForReview: false,
+  owners: [],
+  sourceInfo: {},
+  stafferInfo: {},
   targetRun: null,
 };
 

--- a/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import CollapsibleCourseRun from './CollapsibleCourseRun';
+import courseSubmitInfo from '../../data/actions/courseSubmitInfo';
+import store from '../../data/store';
 
 const languageOptions = [
   {
@@ -33,8 +35,6 @@ const publishedCourseRun = {
 
 const unpublishedCourseRun = Object.assign({}, publishedCourseRun, { status: 'unpublished' });
 
-const mockSubmit = jest.fn();
-
 describe('Collapsible Course Run', () => {
   it('renders correctly with no fields', () => {
     const component = shallow(<CollapsibleCourseRun
@@ -42,7 +42,7 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={[]}
       courseRun={{}}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
     />);
     expect(component).toMatchSnapshot();
   });
@@ -53,7 +53,7 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={pacingTypeOptions}
       courseRun={publishedCourseRun}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
     />);
     expect(component).toMatchSnapshot();
   });
@@ -64,7 +64,7 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={pacingTypeOptions}
       courseRun={unpublishedCourseRun}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
     />);
     expect(component).toMatchSnapshot();
   });
@@ -75,7 +75,7 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={pacingTypeOptions}
       courseRun={unpublishedCourseRun}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
       isSubmittingForReview
     />);
     expect(component).toMatchSnapshot();
@@ -87,7 +87,7 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={pacingTypeOptions}
       courseRun={publishedCourseRun}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
       isSubmittingForReview
     />);
     expect(component).toMatchSnapshot();
@@ -100,7 +100,7 @@ describe('Collapsible Course Run', () => {
       courseRun={{}}
       courseInReview
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
     />);
     const childFields = component.find('input');
     childFields.forEach((field) => {
@@ -114,14 +114,11 @@ describe('Collapsible Course Run', () => {
       pacingTypeOptions={pacingTypeOptions}
       courseRun={unpublishedCourseRun}
       courseId="test-course"
-      handleSubmit={mockSubmit}
+      courseUuid="11111111-1111-1111-1111-111111111111"
     />);
 
-    component.find('ActionButton').simulate(
-      'click',
-      { preventDefault: () => {} },
-    );
-
-    expect(mockSubmit).toHaveBeenCalled();
+    const mockDispatch = jest.spyOn(store, 'dispatch');
+    component.find('ActionButton').simulate('click');
+    expect(mockDispatch).toHaveBeenCalledWith(courseSubmitInfo(unpublishedCourseRun));
   });
 });

--- a/src/components/EditCoursePage/CollapsibleCourseRuns.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRuns.jsx
@@ -14,6 +14,7 @@ const CollapsibleCourseRuns = ({
         {...passThroughProps}
         courseRun={courseRuns[index]}
         courseId={courseRun}
+        key={courseRuns[index].key}
       />
     ))}
   </div>

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -774,16 +774,12 @@ const EditCourseForm = compose(
     // Run the sync validation when a run is submitting for review and regular submission process
     shouldError: (params) => {
       const { nextProps, props } = params;
-      if (
+      return (
         props.submitting ||
         (nextProps && nextProps.submitting) ||
         props.targetRun ||
         (nextProps && nextProps.targetRun)
-      ) {
-        return true;
-      }
-
-      return false;
+      );
     },
     validate: editCourseValidate,
   }),

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { submit } from 'redux-form';
 
 import EditCoursePage from './index';
-import { PUBLISHED, UNPUBLISHED } from '../../data/constants';
-import store from '../../data/store';
 
 
 describe('EditCoursePage', () => {
@@ -253,96 +250,5 @@ describe('EditCoursePage', () => {
       }}
     />);
     expect(component).toMatchSnapshot();
-  });
-
-  describe('EditCoursePage submission handling', () => {
-    const mockValidateSubmit = jest.fn();
-    const publishedCourseRun = {
-      key: 'edX101+DemoX',
-      status: PUBLISHED,
-    };
-    const unpublishedCourseRun = Object.assign(
-      {},
-      publishedCourseRun,
-      { status: UNPUBLISHED },
-    );
-
-    const getMockForm = valid => ({
-      checkValidity: jest.fn(() => valid),
-      reportValidity: jest.fn(() => {}),
-    });
-
-    it('sets state correctly and calls validateSubmit when submission is triggered with no target run', () => {
-      const component = shallow(<EditCoursePage
-        courseInfo={courseInfo}
-      />);
-
-      // Stub validateSubmit for this test
-      component.instance().validateSubmit = mockValidateSubmit;
-      component.update();
-
-      component.instance().handleSubmit();
-      expect(component.state().targetRun).toEqual(null);
-      expect(component.state().isSubmittingForReview).toEqual(false);
-      expect(mockValidateSubmit).toBeCalled();
-    });
-
-    it('sets state correctly and calls validateSubmit when submission is triggered with unpublished target run', () => {
-      const component = shallow(<EditCoursePage
-        courseInfo={courseInfo}
-      />);
-
-      // Stub validateSubmit for this test
-      component.instance().validateSubmit = mockValidateSubmit;
-      component.update();
-
-      component.instance().handleSubmit(unpublishedCourseRun);
-      expect(component.state().targetRun).toEqual(unpublishedCourseRun);
-      expect(component.state().isSubmittingForReview).toEqual(true);
-      expect(mockValidateSubmit).toBeCalled();
-    });
-
-    it('sets state correctly and calls validateSubmit when submission is triggered with published target run', () => {
-      const component = shallow(<EditCoursePage
-        courseInfo={courseInfo}
-      />);
-
-      // Stub validateSubmit for this test
-      component.instance().validateSubmit = mockValidateSubmit;
-      component.update();
-
-      component.instance().handleSubmit(publishedCourseRun);
-      expect(component.state().targetRun).toEqual(publishedCourseRun);
-      expect(component.state().isSubmittingForReview).toEqual(false);
-      expect(mockValidateSubmit).toBeCalled();
-    });
-
-    it('reports validity when there are invalid fields', () => {
-      const component = shallow(<EditCoursePage
-        courseInfo={courseInfo}
-      />);
-
-      const mockInvalidForm = getMockForm(false);
-      jest.spyOn(document, 'getElementById').mockImplementation(() => mockInvalidForm);
-
-      component.instance().validateSubmit();
-      expect(mockInvalidForm.reportValidity).toHaveBeenCalled();
-    });
-
-    it('does not report validity when fields are valid and dispatches the expected submit action', () => {
-      const component = shallow(<EditCoursePage
-        courseInfo={courseInfo}
-      />);
-
-
-      const mockValidForm = getMockForm(true);
-      jest.spyOn(document, 'getElementById').mockImplementation(() => mockValidForm);
-      const mockDispatch = jest.spyOn(store, 'dispatch').mockImplementation(() => {});
-      const expectedAction = submit(component.instance().getFormId());
-
-      component.instance().validateSubmit();
-      expect(mockDispatch).toHaveBeenCalledWith(expectedAction);
-      expect(mockValidForm.reportValidity).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/components/EditCoursePage/TranscriptLanguage.jsx
+++ b/src/components/EditCoursePage/TranscriptLanguage.jsx
@@ -5,6 +5,7 @@ import { Field } from 'redux-form';
 import RenderSelectField from '../RenderSelectField';
 import RemoveButton from '../RemoveButton';
 import FieldLabel from '../FieldLabel';
+import StatusAlert from '../StatusAlert';
 
 class TranscriptLanguage extends React.Component {
   constructor(props) {
@@ -17,10 +18,25 @@ class TranscriptLanguage extends React.Component {
   }
 
   render() {
-    const { fields, languageOptions, disabled } = this.props;
+    const {
+      fields,
+      languageOptions,
+      disabled,
+      meta: {
+        submitFailed,
+        error,
+      },
+    } = this.props;
 
     return (
-      <div className="transcript-languages mb-3">
+      // Set tabindex to -1 to allow programmatic shifting of focus for validation
+      <div className="transcript-languages mb-3" name={fields.name} tabIndex="-1">
+        {submitFailed && error &&
+          <StatusAlert
+            alertType="danger"
+            message={error}
+          />
+        }
         <ul className="list-group p-0 m-0 container-fluid">
           {fields.map((language, index) => (
             <li className="transcript-language list-group-item row d-flex align-items-center px-0 mx-0" key={language}>
@@ -62,6 +78,7 @@ class TranscriptLanguage extends React.Component {
 TranscriptLanguage.propTypes = {
   fields: PropTypes.shape({
     remove: PropTypes.func,
+    name: PropTypes.string,
   }).isRequired,
   languageOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
@@ -69,6 +86,10 @@ TranscriptLanguage.propTypes = {
   })).isRequired,
   disabled: PropTypes.bool,
   extraInput: PropTypes.shape({}),
+  meta: PropTypes.shape({
+    submitFailed: PropTypes.bool,
+    error: PropTypes.string,
+  }).isRequired,
 };
 
 TranscriptLanguage.defaultProps = {

--- a/src/components/EditCoursePage/TranscriptLanguage.test.jsx
+++ b/src/components/EditCoursePage/TranscriptLanguage.test.jsx
@@ -18,11 +18,22 @@ const languageOptions = [{
   value: 'ar-ae',
 }];
 
+const meta = {
+  submitFailed: false,
+  error: '',
+};
+
+const metaFailed = {
+  submitFailed: true,
+  error: 'This field is required',
+};
+
 describe('Transcript Language', () => {
   it('renders correctly with no fields', () => {
     const component = shallow(<TranscriptLanguage
       fields={[]}
       languageOptions={languageOptions}
+      meta={meta}
     />);
     expect(component).toMatchSnapshot();
   });
@@ -31,6 +42,16 @@ describe('Transcript Language', () => {
     const component = shallow(<TranscriptLanguage
       fields={[{}]}
       languageOptions={languageOptions}
+      meta={meta}
+    />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly with an error after failed submission', () => {
+    const component = shallow(<TranscriptLanguage
+      fields={[{}]}
+      languageOptions={languageOptions}
+      meta={metaFailed}
     />);
     expect(component).toMatchSnapshot();
   });
@@ -40,6 +61,7 @@ describe('Transcript Language', () => {
     const component = shallow(<TranscriptLanguage
       fields={fields}
       languageOptions={languageOptions}
+      meta={meta}
     />);
     expect(fields.length).toEqual(1);
 

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -24,7 +24,7 @@ ShallowWrapper {
       }
     }
     courseSubmitting={false}
-    handleSubmit={[MockFunction]}
+    courseUuid="11111111-1111-1111-1111-111111111111"
     isSubmittingForReview={false}
     languageOptions={
       Array [
@@ -34,6 +34,7 @@ ShallowWrapper {
         },
       ]
     }
+    owners={Array []}
     pacingTypeOptions={
       Array [
         Object {
@@ -42,6 +43,8 @@ ShallowWrapper {
         },
       ]
     }
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
     targetRun={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -55,7 +58,7 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "collapsible-run-test-course",
+    "key": undefined,
     "nodeType": "class",
     "props": Object {
       "children": Array [
@@ -309,7 +312,6 @@ ShallowWrapper {
             ]
           }
           name="test-course.transcript_languages"
-          required={false}
         />,
         <Field
           component={[Function]}
@@ -359,6 +361,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           courseRunKey="edX101+DemoX"
+          courseUuid="11111111-1111-1111-1111-111111111111"
           disabled={false}
           extraInput={
             Object {
@@ -366,7 +369,9 @@ ShallowWrapper {
             }
           }
           name="test-course.staff"
-          required={false}
+          owners={Array []}
+          sourceInfo={Object {}}
+          stafferInfo={Object {}}
         />,
         <ButtonToolbar
           className=""
@@ -699,7 +704,6 @@ ShallowWrapper {
             },
           ],
           "name": "test-course.transcript_languages",
-          "required": false,
         },
         "ref": null,
         "rendered": null,
@@ -767,12 +771,15 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
+          "courseUuid": "11111111-1111-1111-1111-111111111111",
           "disabled": false,
           "extraInput": Object {
             "onInvalid": [Function],
           },
           "name": "test-course.staff",
-          "required": false,
+          "owners": Array [],
+          "sourceInfo": Object {},
+          "stafferInfo": Object {},
         },
         "ref": null,
         "rendered": null,
@@ -824,7 +831,7 @@ ShallowWrapper {
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "collapsible-run-test-course",
+      "key": undefined,
       "nodeType": "class",
       "props": Object {
         "children": Array [
@@ -1078,7 +1085,6 @@ ShallowWrapper {
               ]
             }
             name="test-course.transcript_languages"
-            required={false}
           />,
           <Field
             component={[Function]}
@@ -1128,6 +1134,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             courseRunKey="edX101+DemoX"
+            courseUuid="11111111-1111-1111-1111-111111111111"
             disabled={false}
             extraInput={
               Object {
@@ -1135,7 +1142,9 @@ ShallowWrapper {
               }
             }
             name="test-course.staff"
-            required={false}
+            owners={Array []}
+            sourceInfo={Object {}}
+            stafferInfo={Object {}}
           />,
           <ButtonToolbar
             className=""
@@ -1468,7 +1477,6 @@ ShallowWrapper {
               },
             ],
             "name": "test-course.transcript_languages",
-            "required": false,
           },
           "ref": null,
           "rendered": null,
@@ -1536,12 +1544,15 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
+            "courseUuid": "11111111-1111-1111-1111-111111111111",
             "disabled": false,
             "extraInput": Object {
               "onInvalid": [Function],
             },
             "name": "test-course.staff",
-            "required": false,
+            "owners": Array [],
+            "sourceInfo": Object {},
+            "stafferInfo": Object {},
           },
           "ref": null,
           "rendered": null,
@@ -1642,7 +1653,7 @@ ShallowWrapper {
       }
     }
     courseSubmitting={false}
-    handleSubmit={[MockFunction]}
+    courseUuid="11111111-1111-1111-1111-111111111111"
     isSubmittingForReview={false}
     languageOptions={
       Array [
@@ -1652,6 +1663,7 @@ ShallowWrapper {
         },
       ]
     }
+    owners={Array []}
     pacingTypeOptions={
       Array [
         Object {
@@ -1660,6 +1672,8 @@ ShallowWrapper {
         },
       ]
     }
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
     targetRun={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -1673,7 +1687,7 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "collapsible-run-test-course",
+    "key": undefined,
     "nodeType": "class",
     "props": Object {
       "children": Array [
@@ -1927,7 +1941,6 @@ ShallowWrapper {
             ]
           }
           name="test-course.transcript_languages"
-          required={false}
         />,
         <Field
           component={[Function]}
@@ -1977,6 +1990,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           courseRunKey="edX101+DemoX"
+          courseUuid="11111111-1111-1111-1111-111111111111"
           disabled={false}
           extraInput={
             Object {
@@ -1984,7 +1998,9 @@ ShallowWrapper {
             }
           }
           name="test-course.staff"
-          required={false}
+          owners={Array []}
+          sourceInfo={Object {}}
+          stafferInfo={Object {}}
         />,
         <ButtonToolbar
           className=""
@@ -2317,7 +2333,6 @@ ShallowWrapper {
             },
           ],
           "name": "test-course.transcript_languages",
-          "required": false,
         },
         "ref": null,
         "rendered": null,
@@ -2385,12 +2400,15 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
+          "courseUuid": "11111111-1111-1111-1111-111111111111",
           "disabled": false,
           "extraInput": Object {
             "onInvalid": [Function],
           },
           "name": "test-course.staff",
-          "required": false,
+          "owners": Array [],
+          "sourceInfo": Object {},
+          "stafferInfo": Object {},
         },
         "ref": null,
         "rendered": null,
@@ -2442,7 +2460,7 @@ ShallowWrapper {
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "collapsible-run-test-course",
+      "key": undefined,
       "nodeType": "class",
       "props": Object {
         "children": Array [
@@ -2696,7 +2714,6 @@ ShallowWrapper {
               ]
             }
             name="test-course.transcript_languages"
-            required={false}
           />,
           <Field
             component={[Function]}
@@ -2746,6 +2763,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             courseRunKey="edX101+DemoX"
+            courseUuid="11111111-1111-1111-1111-111111111111"
             disabled={false}
             extraInput={
               Object {
@@ -2753,7 +2771,9 @@ ShallowWrapper {
               }
             }
             name="test-course.staff"
-            required={false}
+            owners={Array []}
+            sourceInfo={Object {}}
+            stafferInfo={Object {}}
           />,
           <ButtonToolbar
             className=""
@@ -3086,7 +3106,6 @@ ShallowWrapper {
               },
             ],
             "name": "test-course.transcript_languages",
-            "required": false,
           },
           "ref": null,
           "rendered": null,
@@ -3154,12 +3173,15 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
+            "courseUuid": "11111111-1111-1111-1111-111111111111",
             "disabled": false,
             "extraInput": Object {
               "onInvalid": [Function],
             },
             "name": "test-course.staff",
-            "required": false,
+            "owners": Array [],
+            "sourceInfo": Object {},
+            "stafferInfo": Object {},
           },
           "ref": null,
           "rendered": null,
@@ -3260,7 +3282,7 @@ ShallowWrapper {
       }
     }
     courseSubmitting={false}
-    handleSubmit={[MockFunction]}
+    courseUuid="11111111-1111-1111-1111-111111111111"
     isSubmittingForReview={true}
     languageOptions={
       Array [
@@ -3270,6 +3292,7 @@ ShallowWrapper {
         },
       ]
     }
+    owners={Array []}
     pacingTypeOptions={
       Array [
         Object {
@@ -3278,6 +3301,8 @@ ShallowWrapper {
         },
       ]
     }
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
     targetRun={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -3291,7 +3316,7 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "collapsible-run-test-course",
+    "key": undefined,
     "nodeType": "class",
     "props": Object {
       "children": Array [
@@ -3545,7 +3570,6 @@ ShallowWrapper {
             ]
           }
           name="test-course.transcript_languages"
-          required={null}
         />,
         <Field
           component={[Function]}
@@ -3595,6 +3619,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           courseRunKey="edX101+DemoX"
+          courseUuid="11111111-1111-1111-1111-111111111111"
           disabled={false}
           extraInput={
             Object {
@@ -3602,7 +3627,9 @@ ShallowWrapper {
             }
           }
           name="test-course.staff"
-          required={null}
+          owners={Array []}
+          sourceInfo={Object {}}
+          stafferInfo={Object {}}
         />,
         <ButtonToolbar
           className=""
@@ -3935,7 +3962,6 @@ ShallowWrapper {
             },
           ],
           "name": "test-course.transcript_languages",
-          "required": null,
         },
         "ref": null,
         "rendered": null,
@@ -4003,12 +4029,15 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
+          "courseUuid": "11111111-1111-1111-1111-111111111111",
           "disabled": false,
           "extraInput": Object {
             "onInvalid": [Function],
           },
           "name": "test-course.staff",
-          "required": null,
+          "owners": Array [],
+          "sourceInfo": Object {},
+          "stafferInfo": Object {},
         },
         "ref": null,
         "rendered": null,
@@ -4060,7 +4089,7 @@ ShallowWrapper {
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "collapsible-run-test-course",
+      "key": undefined,
       "nodeType": "class",
       "props": Object {
         "children": Array [
@@ -4314,7 +4343,6 @@ ShallowWrapper {
               ]
             }
             name="test-course.transcript_languages"
-            required={null}
           />,
           <Field
             component={[Function]}
@@ -4364,6 +4392,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             courseRunKey="edX101+DemoX"
+            courseUuid="11111111-1111-1111-1111-111111111111"
             disabled={false}
             extraInput={
               Object {
@@ -4371,7 +4400,9 @@ ShallowWrapper {
               }
             }
             name="test-course.staff"
-            required={null}
+            owners={Array []}
+            sourceInfo={Object {}}
+            stafferInfo={Object {}}
           />,
           <ButtonToolbar
             className=""
@@ -4704,7 +4735,6 @@ ShallowWrapper {
               },
             ],
             "name": "test-course.transcript_languages",
-            "required": null,
           },
           "ref": null,
           "rendered": null,
@@ -4772,12 +4802,15 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
+            "courseUuid": "11111111-1111-1111-1111-111111111111",
             "disabled": false,
             "extraInput": Object {
               "onInvalid": [Function],
             },
             "name": "test-course.staff",
-            "required": null,
+            "owners": Array [],
+            "sourceInfo": Object {},
+            "stafferInfo": Object {},
           },
           "ref": null,
           "rendered": null,
@@ -4878,7 +4911,7 @@ ShallowWrapper {
       }
     }
     courseSubmitting={false}
-    handleSubmit={[MockFunction]}
+    courseUuid="11111111-1111-1111-1111-111111111111"
     isSubmittingForReview={true}
     languageOptions={
       Array [
@@ -4888,6 +4921,7 @@ ShallowWrapper {
         },
       ]
     }
+    owners={Array []}
     pacingTypeOptions={
       Array [
         Object {
@@ -4896,6 +4930,8 @@ ShallowWrapper {
         },
       ]
     }
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
     targetRun={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -4909,7 +4945,7 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "collapsible-run-test-course",
+    "key": undefined,
     "nodeType": "class",
     "props": Object {
       "children": Array [
@@ -5163,7 +5199,6 @@ ShallowWrapper {
             ]
           }
           name="test-course.transcript_languages"
-          required={null}
         />,
         <Field
           component={[Function]}
@@ -5213,6 +5248,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           courseRunKey="edX101+DemoX"
+          courseUuid="11111111-1111-1111-1111-111111111111"
           disabled={false}
           extraInput={
             Object {
@@ -5220,7 +5256,9 @@ ShallowWrapper {
             }
           }
           name="test-course.staff"
-          required={null}
+          owners={Array []}
+          sourceInfo={Object {}}
+          stafferInfo={Object {}}
         />,
         <ButtonToolbar
           className=""
@@ -5553,7 +5591,6 @@ ShallowWrapper {
             },
           ],
           "name": "test-course.transcript_languages",
-          "required": null,
         },
         "ref": null,
         "rendered": null,
@@ -5621,12 +5658,15 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
+          "courseUuid": "11111111-1111-1111-1111-111111111111",
           "disabled": false,
           "extraInput": Object {
             "onInvalid": [Function],
           },
           "name": "test-course.staff",
-          "required": null,
+          "owners": Array [],
+          "sourceInfo": Object {},
+          "stafferInfo": Object {},
         },
         "ref": null,
         "rendered": null,
@@ -5678,7 +5718,7 @@ ShallowWrapper {
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "collapsible-run-test-course",
+      "key": undefined,
       "nodeType": "class",
       "props": Object {
         "children": Array [
@@ -5932,7 +5972,6 @@ ShallowWrapper {
               ]
             }
             name="test-course.transcript_languages"
-            required={null}
           />,
           <Field
             component={[Function]}
@@ -5982,6 +6021,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             courseRunKey="edX101+DemoX"
+            courseUuid="11111111-1111-1111-1111-111111111111"
             disabled={false}
             extraInput={
               Object {
@@ -5989,7 +6029,9 @@ ShallowWrapper {
               }
             }
             name="test-course.staff"
-            required={null}
+            owners={Array []}
+            sourceInfo={Object {}}
+            stafferInfo={Object {}}
           />,
           <ButtonToolbar
             className=""
@@ -6322,7 +6364,6 @@ ShallowWrapper {
               },
             ],
             "name": "test-course.transcript_languages",
-            "required": null,
           },
           "ref": null,
           "rendered": null,
@@ -6390,12 +6431,15 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
+            "courseUuid": "11111111-1111-1111-1111-111111111111",
             "disabled": false,
             "extraInput": Object {
               "onInvalid": [Function],
             },
             "name": "test-course.staff",
-            "required": null,
+            "owners": Array [],
+            "sourceInfo": Object {},
+            "stafferInfo": Object {},
           },
           "ref": null,
           "rendered": null,
@@ -6480,10 +6524,13 @@ ShallowWrapper {
     courseInReview={false}
     courseRun={Object {}}
     courseSubmitting={false}
-    handleSubmit={[MockFunction]}
+    courseUuid="11111111-1111-1111-1111-111111111111"
     isSubmittingForReview={false}
     languageOptions={Array []}
+    owners={Array []}
     pacingTypeOptions={Array []}
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
     targetRun={null}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -6497,7 +6544,7 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": "collapsible-run-test-course",
+    "key": undefined,
     "nodeType": "class",
     "props": Object {
       "children": Array [
@@ -6730,7 +6777,6 @@ ShallowWrapper {
           }
           languageOptions={Array []}
           name="test-course.transcript_languages"
-          required={false}
         />,
         <Field
           component={[Function]}
@@ -6779,6 +6825,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
+          courseUuid="11111111-1111-1111-1111-111111111111"
           disabled={false}
           extraInput={
             Object {
@@ -6786,7 +6833,9 @@ ShallowWrapper {
             }
           }
           name="test-course.staff"
-          required={false}
+          owners={Array []}
+          sourceInfo={Object {}}
+          stafferInfo={Object {}}
         />,
         <ButtonToolbar
           className=""
@@ -7104,7 +7153,6 @@ ShallowWrapper {
           },
           "languageOptions": Array [],
           "name": "test-course.transcript_languages",
-          "required": false,
         },
         "ref": null,
         "rendered": null,
@@ -7172,12 +7220,15 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "courseRunKey": undefined,
+          "courseUuid": "11111111-1111-1111-1111-111111111111",
           "disabled": false,
           "extraInput": Object {
             "onInvalid": [Function],
           },
           "name": "test-course.staff",
-          "required": false,
+          "owners": Array [],
+          "sourceInfo": Object {},
+          "stafferInfo": Object {},
         },
         "ref": null,
         "rendered": null,
@@ -7229,7 +7280,7 @@ ShallowWrapper {
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
-      "key": "collapsible-run-test-course",
+      "key": undefined,
       "nodeType": "class",
       "props": Object {
         "children": Array [
@@ -7462,7 +7513,6 @@ ShallowWrapper {
             }
             languageOptions={Array []}
             name="test-course.transcript_languages"
-            required={false}
           />,
           <Field
             component={[Function]}
@@ -7511,6 +7561,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
+            courseUuid="11111111-1111-1111-1111-111111111111"
             disabled={false}
             extraInput={
               Object {
@@ -7518,7 +7569,9 @@ ShallowWrapper {
               }
             }
             name="test-course.staff"
-            required={false}
+            owners={Array []}
+            sourceInfo={Object {}}
+            stafferInfo={Object {}}
           />,
           <ButtonToolbar
             className=""
@@ -7836,7 +7889,6 @@ ShallowWrapper {
             },
             "languageOptions": Array [],
             "name": "test-course.transcript_languages",
-            "required": false,
           },
           "ref": null,
           "rendered": null,
@@ -7904,12 +7956,15 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "courseRunKey": undefined,
+            "courseUuid": "11111111-1111-1111-1111-111111111111",
             "disabled": false,
             "extraInput": Object {
               "onInvalid": [Function],
             },
             "name": "test-course.staff",
-            "required": false,
+            "owners": Array [],
+            "sourceInfo": Object {},
+            "stafferInfo": Object {},
           },
           "ref": null,
           "rendered": null,

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -663,6 +663,7 @@ ShallowWrapper {
     "props": Object {
       "children": <form
         id="edit-course-form"
+        onSubmit={[Function]}
       >
         <FieldLabel
           className="mt-4 mb-2 h2"
@@ -820,7 +821,6 @@ ShallowWrapper {
             }
             maxChars={500}
             name="short_description"
-            required={true}
           />
           <Field
             component={[Function]}
@@ -878,7 +878,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="full_description"
-            required={true}
           />
           <Field
             component={[Function]}
@@ -938,7 +937,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="outcome"
-            required={true}
           />
           <Field
             component={[Function]}
@@ -2937,7 +2935,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -2995,7 +2992,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -3055,7 +3051,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -4890,6 +4885,7 @@ ShallowWrapper {
           </ButtonToolbar>,
         ],
         "id": "edit-course-form",
+        "onSubmit": [Function],
       },
       "ref": null,
       "rendered": Array [
@@ -5050,7 +5046,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={true}
               />,
               <Field
                 component={[Function]}
@@ -5108,7 +5103,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={true}
               />,
               <Field
                 component={[Function]}
@@ -5168,7 +5162,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={true}
               />,
               <Field
                 component={[Function]}
@@ -5941,7 +5934,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 500,
                 "name": "short_description",
-                "required": true,
               },
               "ref": null,
               "rendered": null,
@@ -6003,7 +5995,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "full_description",
-                "required": true,
               },
               "ref": null,
               "rendered": null,
@@ -6067,7 +6058,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "outcome",
-                "required": true,
               },
               "ref": null,
               "rendered": null,
@@ -8023,6 +8013,7 @@ ShallowWrapper {
       "props": Object {
         "children": <form
           id="edit-course-form"
+          onSubmit={[Function]}
         >
           <FieldLabel
             className="mt-4 mb-2 h2"
@@ -8180,7 +8171,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -8238,7 +8228,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -8298,7 +8287,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={true}
             />
             <Field
               component={[Function]}
@@ -10297,7 +10285,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={true}
               />
               <Field
                 component={[Function]}
@@ -10355,7 +10342,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={true}
               />
               <Field
                 component={[Function]}
@@ -10415,7 +10401,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={true}
               />
               <Field
                 component={[Function]}
@@ -12250,6 +12235,7 @@ ShallowWrapper {
             </ButtonToolbar>,
           ],
           "id": "edit-course-form",
+          "onSubmit": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -12410,7 +12396,6 @@ ShallowWrapper {
                   }
                   maxChars={500}
                   name="short_description"
-                  required={true}
                 />,
                 <Field
                   component={[Function]}
@@ -12468,7 +12453,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="full_description"
-                  required={true}
                 />,
                 <Field
                   component={[Function]}
@@ -12528,7 +12512,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="outcome"
-                  required={true}
                 />,
                 <Field
                   component={[Function]}
@@ -13301,7 +13284,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 500,
                   "name": "short_description",
-                  "required": true,
                 },
                 "ref": null,
                 "rendered": null,
@@ -13363,7 +13345,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "full_description",
-                  "required": true,
                 },
                 "ref": null,
                 "rendered": null,
@@ -13427,7 +13408,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "outcome",
-                  "required": true,
                 },
                 "ref": null,
                 "rendered": null,
@@ -16088,6 +16068,7 @@ ShallowWrapper {
     "props": Object {
       "children": <form
         id="edit-course-form"
+        onSubmit={[Function]}
       >
         <FieldLabel
           className="mt-4 mb-2 h2"
@@ -16245,7 +16226,6 @@ ShallowWrapper {
             }
             maxChars={500}
             name="short_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -16303,7 +16283,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="full_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -16363,7 +16342,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="outcome"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -18461,7 +18439,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -18519,7 +18496,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -18579,7 +18555,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -20513,6 +20488,7 @@ ShallowWrapper {
           </ButtonToolbar>,
         ],
         "id": "edit-course-form",
+        "onSubmit": [Function],
       },
       "ref": null,
       "rendered": Array [
@@ -20673,7 +20649,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -20731,7 +20706,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -20791,7 +20765,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -21640,7 +21613,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 500,
                 "name": "short_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -21702,7 +21674,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "full_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -21766,7 +21737,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "outcome",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -23910,6 +23880,7 @@ ShallowWrapper {
       "props": Object {
         "children": <form
           id="edit-course-form"
+          onSubmit={[Function]}
         >
           <FieldLabel
             className="mt-4 mb-2 h2"
@@ -24067,7 +24038,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -24125,7 +24095,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -24185,7 +24154,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -26283,7 +26251,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -26341,7 +26308,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -26401,7 +26367,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -28335,6 +28300,7 @@ ShallowWrapper {
             </ButtonToolbar>,
           ],
           "id": "edit-course-form",
+          "onSubmit": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -28495,7 +28461,6 @@ ShallowWrapper {
                   }
                   maxChars={500}
                   name="short_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -28553,7 +28518,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="full_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -28613,7 +28577,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="outcome"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -29462,7 +29425,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 500,
                   "name": "short_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -29524,7 +29486,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "full_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -29588,7 +29549,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "outcome",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -32437,6 +32397,7 @@ ShallowWrapper {
     "props": Object {
       "children": <form
         id="edit-course-form"
+        onSubmit={[Function]}
       >
         <FieldLabel
           className="mt-4 mb-2 h2"
@@ -32594,7 +32555,6 @@ ShallowWrapper {
             }
             maxChars={500}
             name="short_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -32652,7 +32612,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="full_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -32712,7 +32671,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="outcome"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -34733,7 +34691,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -34791,7 +34748,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -34851,7 +34807,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -36708,6 +36663,7 @@ ShallowWrapper {
           </ButtonToolbar>,
         ],
         "id": "edit-course-form",
+        "onSubmit": [Function],
       },
       "ref": null,
       "rendered": Array [
@@ -36868,7 +36824,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -36926,7 +36881,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -36986,7 +36940,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -37759,7 +37712,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 500,
                 "name": "short_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -37821,7 +37773,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "full_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -37885,7 +37836,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "outcome",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -39861,6 +39811,7 @@ ShallowWrapper {
       "props": Object {
         "children": <form
           id="edit-course-form"
+          onSubmit={[Function]}
         >
           <FieldLabel
             className="mt-4 mb-2 h2"
@@ -40018,7 +39969,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -40076,7 +40026,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -40136,7 +40085,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -42157,7 +42105,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -42215,7 +42162,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -42275,7 +42221,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -44132,6 +44077,7 @@ ShallowWrapper {
             </ButtonToolbar>,
           ],
           "id": "edit-course-form",
+          "onSubmit": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -44292,7 +44238,6 @@ ShallowWrapper {
                   }
                   maxChars={500}
                   name="short_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -44350,7 +44295,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="full_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -44410,7 +44354,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="outcome"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -45183,7 +45126,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 500,
                   "name": "short_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -45245,7 +45187,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "full_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -45309,7 +45250,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "outcome",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -47973,6 +47913,7 @@ ShallowWrapper {
     "props": Object {
       "children": <form
         id="edit-course-form"
+        onSubmit={[Function]}
       >
         <FieldLabel
           className="mt-4 mb-2 h2"
@@ -48130,7 +48071,6 @@ ShallowWrapper {
             }
             maxChars={500}
             name="short_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -48188,7 +48128,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="full_description"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -48248,7 +48187,6 @@ ShallowWrapper {
             }
             maxChars={2500}
             name="outcome"
-            required={false}
           />
           <Field
             component={[Function]}
@@ -50252,7 +50190,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -50310,7 +50247,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -50370,7 +50306,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -52210,6 +52145,7 @@ ShallowWrapper {
           </ButtonToolbar>,
         ],
         "id": "edit-course-form",
+        "onSubmit": [Function],
       },
       "ref": null,
       "rendered": Array [
@@ -52370,7 +52306,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -52428,7 +52363,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -52488,7 +52422,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />,
               <Field
                 component={[Function]}
@@ -53261,7 +53194,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 500,
                 "name": "short_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -53323,7 +53255,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "full_description",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -53387,7 +53318,6 @@ ShallowWrapper {
                 />,
                 "maxChars": 2500,
                 "name": "outcome",
-                "required": false,
               },
               "ref": null,
               "rendered": null,
@@ -55346,6 +55276,7 @@ ShallowWrapper {
       "props": Object {
         "children": <form
           id="edit-course-form"
+          onSubmit={[Function]}
         >
           <FieldLabel
             className="mt-4 mb-2 h2"
@@ -55503,7 +55434,6 @@ ShallowWrapper {
               }
               maxChars={500}
               name="short_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -55561,7 +55491,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="full_description"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -55621,7 +55550,6 @@ ShallowWrapper {
               }
               maxChars={2500}
               name="outcome"
-              required={false}
             />
             <Field
               component={[Function]}
@@ -57625,7 +57553,6 @@ ShallowWrapper {
                 }
                 maxChars={500}
                 name="short_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -57683,7 +57610,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="full_description"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -57743,7 +57669,6 @@ ShallowWrapper {
                 }
                 maxChars={2500}
                 name="outcome"
-                required={false}
               />
               <Field
                 component={[Function]}
@@ -59583,6 +59508,7 @@ ShallowWrapper {
             </ButtonToolbar>,
           ],
           "id": "edit-course-form",
+          "onSubmit": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -59743,7 +59669,6 @@ ShallowWrapper {
                   }
                   maxChars={500}
                   name="short_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -59801,7 +59726,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="full_description"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -59861,7 +59785,6 @@ ShallowWrapper {
                   }
                   maxChars={2500}
                   name="outcome"
-                  required={false}
                 />,
                 <Field
                   component={[Function]}
@@ -60634,7 +60557,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 500,
                   "name": "short_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -60696,7 +60618,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "full_description",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,
@@ -60760,7 +60681,6 @@ ShallowWrapper {
                   />,
                   "maxChars": 2500,
                   "name": "outcome",
-                  "required": false,
                 },
                 "ref": null,
                 "rendered": null,

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -11,6 +11,7 @@ ShallowWrapper {
     }
     courseOptions={Object {}}
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -53,12 +54,12 @@ ShallowWrapper {
               courseOptions={Object {}}
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -134,12 +135,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -190,12 +191,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -238,12 +239,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -315,12 +316,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -396,12 +397,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -452,12 +453,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -500,12 +501,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -595,6 +596,7 @@ ShallowWrapper {
       }
     }
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -878,6 +880,7 @@ ShallowWrapper {
     }
     courseOptions={Object {}}
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -975,12 +978,12 @@ ShallowWrapper {
               courseOptions={Object {}}
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={true}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-00000000-0000-0000-0000-000000000000"
               initialValues={
                 Object {
@@ -1114,12 +1117,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -1228,12 +1231,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -1334,12 +1337,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": true,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                 "initialValues": Object {
                   "additional_information": "",
@@ -1466,12 +1469,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -1605,12 +1608,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={true}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-00000000-0000-0000-0000-000000000000"
                   initialValues={
                     Object {
@@ -1719,12 +1722,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={true}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-00000000-0000-0000-0000-000000000000"
                   initialValues={
                     Object {
@@ -1825,12 +1828,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": true,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                   "initialValues": Object {
                     "additional_information": "",
@@ -2016,6 +2019,7 @@ ShallowWrapper {
       }
     }
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -2162,12 +2166,12 @@ ShallowWrapper {
               }
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={true}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-00000000-0000-0000-0000-000000000000"
               initialValues={
                 Object {
@@ -2350,12 +2354,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -2513,12 +2517,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -2666,12 +2670,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": true,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                 "initialValues": Object {
                   "additional_information": "",
@@ -2847,12 +2851,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={true}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-00000000-0000-0000-0000-000000000000"
                 initialValues={
                   Object {
@@ -3035,12 +3039,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={true}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-00000000-0000-0000-0000-000000000000"
                   initialValues={
                     Object {
@@ -3198,12 +3202,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={true}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-00000000-0000-0000-0000-000000000000"
                   initialValues={
                     Object {
@@ -3351,12 +3355,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": true,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-00000000-0000-0000-0000-000000000000",
                   "initialValues": Object {
                     "additional_information": "",
@@ -3442,6 +3446,7 @@ ShallowWrapper {
     }
     courseOptions={Object {}}
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -3488,12 +3493,12 @@ ShallowWrapper {
               courseOptions={Object {}}
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -3588,12 +3593,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -3662,12 +3667,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -3714,12 +3719,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -3815,12 +3820,12 @@ ShallowWrapper {
                 courseOptions={Object {}}
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -3915,12 +3920,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -3989,12 +3994,12 @@ ShallowWrapper {
                   courseOptions={Object {}}
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -4041,12 +4046,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -4168,6 +4173,7 @@ ShallowWrapper {
         "isFetching": false,
       }
     }
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -4230,12 +4236,12 @@ ShallowWrapper {
                 }
               }
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -4350,12 +4356,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -4444,12 +4450,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -4508,12 +4514,12 @@ ShallowWrapper {
                 },
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -4629,12 +4635,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -4749,12 +4755,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -4843,12 +4849,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -4907,12 +4913,12 @@ ShallowWrapper {
                   },
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -5067,6 +5073,7 @@ ShallowWrapper {
       }
     }
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -5158,12 +5165,12 @@ ShallowWrapper {
               }
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -5288,12 +5295,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -5393,12 +5400,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -5488,12 +5495,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -5614,12 +5621,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -5744,12 +5751,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -5849,12 +5856,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -5944,12 +5951,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -6039,6 +6046,7 @@ ShallowWrapper {
       }
     }
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -6089,12 +6097,12 @@ ShallowWrapper {
               }
               courseRunOptions={Object {}}
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -6193,12 +6201,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -6271,12 +6279,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -6325,12 +6333,12 @@ ShallowWrapper {
                 "courseRunOptions": Object {},
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -6430,12 +6438,12 @@ ShallowWrapper {
                 }
                 courseRunOptions={Object {}}
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -6534,12 +6542,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -6612,12 +6620,12 @@ ShallowWrapper {
                   }
                   courseRunOptions={Object {}}
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -6666,12 +6674,12 @@ ShallowWrapper {
                   "courseRunOptions": Object {},
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -6817,6 +6825,7 @@ ShallowWrapper {
         "isFetching": false,
       }
     }
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -6903,12 +6912,12 @@ ShallowWrapper {
                 }
               }
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -7028,12 +7037,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -7128,12 +7137,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -7218,12 +7227,12 @@ ShallowWrapper {
                 },
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -7339,12 +7348,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -7464,12 +7473,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -7564,12 +7573,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -7654,12 +7663,12 @@ ShallowWrapper {
                   },
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -7749,6 +7758,7 @@ ShallowWrapper {
         "isFetching": false,
       }
     }
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -7799,12 +7809,12 @@ ShallowWrapper {
                 }
               }
               courseStatuses={Array []}
+              courseSubmitInfo={Object {}}
               editCourse={[Function]}
               entitlement={false}
               fetchCourseInfo={[Function]}
               fetchCourseOptions={[Function]}
               fetchCourseRunOptions={[Function]}
-              handleSubmit={[Function]}
               id="edit-course-form-undefined"
               initialValues={
                 Object {
@@ -7903,12 +7913,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -7981,12 +7991,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -8035,12 +8045,12 @@ ShallowWrapper {
                 },
                 "courseRuns": undefined,
                 "courseStatuses": Array [],
+                "courseSubmitInfo": Object {},
                 "editCourse": [Function],
                 "entitlement": false,
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
                 "fetchCourseRunOptions": [Function],
-                "handleSubmit": [Function],
                 "id": "edit-course-form-undefined",
                 "initialValues": Object {
                   "additional_information": undefined,
@@ -8140,12 +8150,12 @@ ShallowWrapper {
                   }
                 }
                 courseStatuses={Array []}
+                courseSubmitInfo={Object {}}
                 editCourse={[Function]}
                 entitlement={false}
                 fetchCourseInfo={[Function]}
                 fetchCourseOptions={[Function]}
                 fetchCourseRunOptions={[Function]}
-                handleSubmit={[Function]}
                 id="edit-course-form-undefined"
                 initialValues={
                   Object {
@@ -8244,12 +8254,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -8322,12 +8332,12 @@ ShallowWrapper {
                     }
                   }
                   courseStatuses={Array []}
+                  courseSubmitInfo={Object {}}
                   editCourse={[Function]}
                   entitlement={false}
                   fetchCourseInfo={[Function]}
                   fetchCourseOptions={[Function]}
                   fetchCourseRunOptions={[Function]}
-                  handleSubmit={[Function]}
                   id="edit-course-form-undefined"
                   initialValues={
                     Object {
@@ -8376,12 +8386,12 @@ ShallowWrapper {
                   },
                   "courseRuns": undefined,
                   "courseStatuses": Array [],
+                  "courseSubmitInfo": Object {},
                   "editCourse": [Function],
                   "entitlement": false,
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
                   "fetchCourseRunOptions": [Function],
-                  "handleSubmit": [Function],
                   "id": "edit-course-form-undefined",
                   "initialValues": Object {
                     "additional_information": undefined,
@@ -8479,6 +8489,7 @@ ShallowWrapper {
     courseInfo={null}
     courseOptions={Object {}}
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -8569,6 +8580,7 @@ ShallowWrapper {
     }
     courseOptions={null}
     courseRunOptions={Object {}}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}
@@ -8659,6 +8671,7 @@ ShallowWrapper {
     }
     courseOptions={Object {}}
     courseRunOptions={null}
+    courseSubmitInfo={Object {}}
     editCourse={[Function]}
     fetchCourseInfo={[Function]}
     fetchCourseOptions={[Function]}

--- a/src/components/EditCoursePage/__snapshots__/TranscriptLanguage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/TranscriptLanguage.test.jsx.snap
@@ -19,6 +19,12 @@ ShallowWrapper {
         },
       ]
     }
+    meta={
+      Object {
+        "error": "",
+        "submitFailed": false,
+      }
+    }
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -35,6 +41,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
+        false,
         <ul
           className="list-group p-0 m-0 container-fluid"
         >
@@ -94,9 +101,12 @@ ShallowWrapper {
         </button>,
       ],
       "className": "transcript-languages mb-3",
+      "name": undefined,
+      "tabIndex": "-1",
     },
     "ref": null,
     "rendered": Array [
+      false,
       Object {
         "instance": null,
         "key": undefined,
@@ -323,6 +333,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
+          false,
           <ul
             className="list-group p-0 m-0 container-fluid"
           >
@@ -382,9 +393,706 @@ ShallowWrapper {
           </button>,
         ],
         "className": "transcript-languages mb-3",
+        "name": undefined,
+        "tabIndex": "-1",
       },
       "ref": null,
       "rendered": Array [
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li
+                className="transcript-language list-group-item row d-flex align-items-center px-0 mx-0"
+              >
+                <div
+                  className="col-11"
+                >
+                  <Field
+                    component={[Function]}
+                    disabled={false}
+                    extraInput={
+                      Object {
+                        "onInvalid": undefined,
+                      }
+                    }
+                    label={
+                      <FieldLabel
+                        className=""
+                        helpText=""
+                        id={null}
+                        required={true}
+                        requiredForSubmit={false}
+                        text="Transcript language"
+                      />
+                    }
+                    name="[object Object]"
+                    options={
+                      Array [
+                        Object {
+                          "label": "Arabic - United Arab Emirates",
+                          "value": "ar-ae",
+                        },
+                      ]
+                    }
+                    required={true}
+                    type="text"
+                  />
+                </div>
+                <RemoveButton
+                  className="col-1"
+                  disabled={false}
+                  label="Remove language"
+                  onRemove={[Function]}
+                  targetFieldNumber={0}
+                />
+              </li>,
+            ],
+            "className": "list-group p-0 m-0 container-fluid",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "[object Object]",
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <div
+                    className="col-11"
+                  >
+                    <Field
+                      component={[Function]}
+                      disabled={false}
+                      extraInput={
+                        Object {
+                          "onInvalid": undefined,
+                        }
+                      }
+                      label={
+                        <FieldLabel
+                          className=""
+                          helpText=""
+                          id={null}
+                          required={true}
+                          requiredForSubmit={false}
+                          text="Transcript language"
+                        />
+                      }
+                      name="[object Object]"
+                      options={
+                        Array [
+                          Object {
+                            "label": "Arabic - United Arab Emirates",
+                            "value": "ar-ae",
+                          },
+                        ]
+                      }
+                      required={true}
+                      type="text"
+                    />
+                  </div>,
+                  <RemoveButton
+                    className="col-1"
+                    disabled={false}
+                    label="Remove language"
+                    onRemove={[Function]}
+                    targetFieldNumber={0}
+                  />,
+                ],
+                "className": "transcript-language list-group-item row d-flex align-items-center px-0 mx-0",
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Field
+                      component={[Function]}
+                      disabled={false}
+                      extraInput={
+                        Object {
+                          "onInvalid": undefined,
+                        }
+                      }
+                      label={
+                        <FieldLabel
+                          className=""
+                          helpText=""
+                          id={null}
+                          required={true}
+                          requiredForSubmit={false}
+                          text="Transcript language"
+                        />
+                      }
+                      name="[object Object]"
+                      options={
+                        Array [
+                          Object {
+                            "label": "Arabic - United Arab Emirates",
+                            "value": "ar-ae",
+                          },
+                        ]
+                      }
+                      required={true}
+                      type="text"
+                    />,
+                    "className": "col-11",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "component": [Function],
+                      "disabled": false,
+                      "extraInput": Object {
+                        "onInvalid": undefined,
+                      },
+                      "label": <FieldLabel
+                        className=""
+                        helpText=""
+                        id={null}
+                        required={true}
+                        requiredForSubmit={false}
+                        text="Transcript language"
+                      />,
+                      "name": "[object Object]",
+                      "options": Array [
+                        Object {
+                          "label": "Arabic - United Arab Emirates",
+                          "value": "ar-ae",
+                        },
+                      ],
+                      "required": true,
+                      "type": "text",
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "className": "col-1",
+                    "disabled": false,
+                    "label": "Remove language",
+                    "onRemove": [Function],
+                    "targetFieldNumber": 0,
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+              ],
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Add language",
+            "className": "btn btn-outline-primary js-add-button mt-2",
+            "disabled": false,
+            "onClick": [Function],
+            "type": "button",
+          },
+          "ref": null,
+          "rendered": "Add language",
+          "type": "button",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__childContext__): null,
+}
+`;
+
+exports[`Transcript Language renders correctly with an error after failed submission 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <TranscriptLanguage
+    disabled={false}
+    extraInput={Object {}}
+    fields={
+      Array [
+        Object {},
+      ]
+    }
+    languageOptions={
+      Array [
+        Object {
+          "label": "Arabic - United Arab Emirates",
+          "value": "ar-ae",
+        },
+      ]
+    }
+    meta={
+      Object {
+        "error": "This field is required",
+        "submitFailed": true,
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <StatusAlert
+          alertType="danger"
+          className=""
+          dismissible={false}
+          iconClassNames={Array []}
+          message="This field is required"
+          onClose={[Function]}
+          title={null}
+        />,
+        <ul
+          className="list-group p-0 m-0 container-fluid"
+        >
+          <li
+            className="transcript-language list-group-item row d-flex align-items-center px-0 mx-0"
+          >
+            <div
+              className="col-11"
+            >
+              <Field
+                component={[Function]}
+                disabled={false}
+                extraInput={
+                  Object {
+                    "onInvalid": undefined,
+                  }
+                }
+                label={
+                  <FieldLabel
+                    className=""
+                    helpText=""
+                    id={null}
+                    required={true}
+                    requiredForSubmit={false}
+                    text="Transcript language"
+                  />
+                }
+                name="[object Object]"
+                options={
+                  Array [
+                    Object {
+                      "label": "Arabic - United Arab Emirates",
+                      "value": "ar-ae",
+                    },
+                  ]
+                }
+                required={true}
+                type="text"
+              />
+            </div>
+            <RemoveButton
+              className="col-1"
+              disabled={false}
+              label="Remove language"
+              onRemove={[Function]}
+              targetFieldNumber={0}
+            />
+          </li>
+        </ul>,
+        <button
+          className="btn btn-outline-primary js-add-button mt-2"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Add language
+        </button>,
+      ],
+      "className": "transcript-languages mb-3",
+      "name": undefined,
+      "tabIndex": "-1",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "alertType": "danger",
+          "className": "",
+          "dismissible": false,
+          "iconClassNames": Array [],
+          "message": "This field is required",
+          "onClose": [Function],
+          "title": null,
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li
+              className="transcript-language list-group-item row d-flex align-items-center px-0 mx-0"
+            >
+              <div
+                className="col-11"
+              >
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  extraInput={
+                    Object {
+                      "onInvalid": undefined,
+                    }
+                  }
+                  label={
+                    <FieldLabel
+                      className=""
+                      helpText=""
+                      id={null}
+                      required={true}
+                      requiredForSubmit={false}
+                      text="Transcript language"
+                    />
+                  }
+                  name="[object Object]"
+                  options={
+                    Array [
+                      Object {
+                        "label": "Arabic - United Arab Emirates",
+                        "value": "ar-ae",
+                      },
+                    ]
+                  }
+                  required={true}
+                  type="text"
+                />
+              </div>
+              <RemoveButton
+                className="col-1"
+                disabled={false}
+                label="Remove language"
+                onRemove={[Function]}
+                targetFieldNumber={0}
+              />
+            </li>,
+          ],
+          "className": "list-group p-0 m-0 container-fluid",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "[object Object]",
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <div
+                  className="col-11"
+                >
+                  <Field
+                    component={[Function]}
+                    disabled={false}
+                    extraInput={
+                      Object {
+                        "onInvalid": undefined,
+                      }
+                    }
+                    label={
+                      <FieldLabel
+                        className=""
+                        helpText=""
+                        id={null}
+                        required={true}
+                        requiredForSubmit={false}
+                        text="Transcript language"
+                      />
+                    }
+                    name="[object Object]"
+                    options={
+                      Array [
+                        Object {
+                          "label": "Arabic - United Arab Emirates",
+                          "value": "ar-ae",
+                        },
+                      ]
+                    }
+                    required={true}
+                    type="text"
+                  />
+                </div>,
+                <RemoveButton
+                  className="col-1"
+                  disabled={false}
+                  label="Remove language"
+                  onRemove={[Function]}
+                  targetFieldNumber={0}
+                />,
+              ],
+              "className": "transcript-language list-group-item row d-flex align-items-center px-0 mx-0",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <Field
+                    component={[Function]}
+                    disabled={false}
+                    extraInput={
+                      Object {
+                        "onInvalid": undefined,
+                      }
+                    }
+                    label={
+                      <FieldLabel
+                        className=""
+                        helpText=""
+                        id={null}
+                        required={true}
+                        requiredForSubmit={false}
+                        text="Transcript language"
+                      />
+                    }
+                    name="[object Object]"
+                    options={
+                      Array [
+                        Object {
+                          "label": "Arabic - United Arab Emirates",
+                          "value": "ar-ae",
+                        },
+                      ]
+                    }
+                    required={true}
+                    type="text"
+                  />,
+                  "className": "col-11",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "component": [Function],
+                    "disabled": false,
+                    "extraInput": Object {
+                      "onInvalid": undefined,
+                    },
+                    "label": <FieldLabel
+                      className=""
+                      helpText=""
+                      id={null}
+                      required={true}
+                      requiredForSubmit={false}
+                      text="Transcript language"
+                    />,
+                    "name": "[object Object]",
+                    "options": Array [
+                      Object {
+                        "label": "Arabic - United Arab Emirates",
+                        "value": "ar-ae",
+                      },
+                    ],
+                    "required": true,
+                    "type": "text",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": "div",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "className": "col-1",
+                  "disabled": false,
+                  "label": "Remove language",
+                  "onRemove": [Function],
+                  "targetFieldNumber": 0,
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+            ],
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Add language",
+          "className": "btn btn-outline-primary js-add-button mt-2",
+          "disabled": false,
+          "onClick": [Function],
+          "type": "button",
+        },
+        "ref": null,
+        "rendered": "Add language",
+        "type": "button",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <StatusAlert
+            alertType="danger"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="This field is required"
+            onClose={[Function]}
+            title={null}
+          />,
+          <ul
+            className="list-group p-0 m-0 container-fluid"
+          >
+            <li
+              className="transcript-language list-group-item row d-flex align-items-center px-0 mx-0"
+            >
+              <div
+                className="col-11"
+              >
+                <Field
+                  component={[Function]}
+                  disabled={false}
+                  extraInput={
+                    Object {
+                      "onInvalid": undefined,
+                    }
+                  }
+                  label={
+                    <FieldLabel
+                      className=""
+                      helpText=""
+                      id={null}
+                      required={true}
+                      requiredForSubmit={false}
+                      text="Transcript language"
+                    />
+                  }
+                  name="[object Object]"
+                  options={
+                    Array [
+                      Object {
+                        "label": "Arabic - United Arab Emirates",
+                        "value": "ar-ae",
+                      },
+                    ]
+                  }
+                  required={true}
+                  type="text"
+                />
+              </div>
+              <RemoveButton
+                className="col-1"
+                disabled={false}
+                label="Remove language"
+                onRemove={[Function]}
+                targetFieldNumber={0}
+              />
+            </li>
+          </ul>,
+          <button
+            className="btn btn-outline-primary js-add-button mt-2"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Add language
+          </button>,
+        ],
+        "className": "transcript-languages mb-3",
+        "name": undefined,
+        "tabIndex": "-1",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "alertType": "danger",
+            "className": "",
+            "dismissible": false,
+            "iconClassNames": Array [],
+            "message": "This field is required",
+            "onClose": [Function],
+            "title": null,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
         Object {
           "instance": null,
           "key": undefined,
@@ -647,6 +1355,12 @@ ShallowWrapper {
         },
       ]
     }
+    meta={
+      Object {
+        "error": "",
+        "submitFailed": false,
+      }
+    }
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -663,6 +1377,7 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
+        false,
         <ul
           className="list-group p-0 m-0 container-fluid"
         />,
@@ -676,9 +1391,12 @@ ShallowWrapper {
         </button>,
       ],
       "className": "transcript-languages mb-3",
+      "name": undefined,
+      "tabIndex": "-1",
     },
     "ref": null,
     "rendered": Array [
+      false,
       Object {
         "instance": null,
         "key": undefined,
@@ -716,6 +1434,7 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
+          false,
           <ul
             className="list-group p-0 m-0 container-fluid"
           />,
@@ -729,9 +1448,12 @@ ShallowWrapper {
           </button>,
         ],
         "className": "transcript-languages mb-3",
+        "name": undefined,
+        "tabIndex": "-1",
       },
       "ref": null,
       "rendered": Array [
+        false,
         Object {
           "instance": null,
           "key": undefined,

--- a/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
+++ b/src/components/RichEditor/__snapshots__/RichEditor.test.jsx.snap
@@ -39,18 +39,11 @@ ShallowWrapper {
         <div
           className="mb-2"
           id="rich-text-editor-test"
+          tabIndex="-1"
         >
           Rich Text Editor Test
         </div>,
-        <StatusAlert
-          alertType="danger"
-          className=""
-          dismissible={false}
-          iconClassNames={Array []}
-          message="Required"
-          onClose={[Function]}
-          title={null}
-        />,
+        undefined,
         <div
           aria-labelledby="rich-text-editor-test"
           className=""
@@ -89,28 +82,14 @@ ShallowWrapper {
           "children": "Rich Text Editor Test",
           "className": "mb-2",
           "id": "rich-text-editor-test",
+          "name": undefined,
+          "tabIndex": "-1",
         },
         "ref": null,
         "rendered": "Rich Text Editor Test",
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "alertType": "danger",
-          "className": "",
-          "dismissible": false,
-          "iconClassNames": Array [],
-          "message": "Required",
-          "onClose": [Function],
-          "title": null,
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
+      undefined,
       Object {
         "instance": null,
         "key": undefined,
@@ -194,18 +173,11 @@ ShallowWrapper {
           <div
             className="mb-2"
             id="rich-text-editor-test"
+            tabIndex="-1"
           >
             Rich Text Editor Test
           </div>,
-          <StatusAlert
-            alertType="danger"
-            className=""
-            dismissible={false}
-            iconClassNames={Array []}
-            message="Required"
-            onClose={[Function]}
-            title={null}
-          />,
+          undefined,
           <div
             aria-labelledby="rich-text-editor-test"
             className=""
@@ -244,28 +216,14 @@ ShallowWrapper {
             "children": "Rich Text Editor Test",
             "className": "mb-2",
             "id": "rich-text-editor-test",
+            "name": undefined,
+            "tabIndex": "-1",
           },
           "ref": null,
           "rendered": "Rich Text Editor Test",
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "alertType": "danger",
-            "className": "",
-            "dismissible": false,
-            "iconClassNames": Array [],
-            "message": "Required",
-            "onClose": [Function],
-            "title": null,
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
+        undefined,
         Object {
           "instance": null,
           "key": undefined,
@@ -410,12 +368,13 @@ ShallowWrapper {
         <div
           className="mb-2"
           id="rich-text-editor-test"
+          tabIndex="-1"
         >
           <strong>
             Rich Text Editor Test
           </strong>
         </div>,
-        false,
+        undefined,
         <div
           aria-labelledby="rich-text-editor-test"
           className=""
@@ -456,6 +415,8 @@ ShallowWrapper {
           </strong>,
           "className": "mb-2",
           "id": "rich-text-editor-test",
+          "name": undefined,
+          "tabIndex": "-1",
         },
         "ref": null,
         "rendered": Object {
@@ -471,7 +432,7 @@ ShallowWrapper {
         },
         "type": "div",
       },
-      false,
+      undefined,
       Object {
         "instance": null,
         "key": undefined,
@@ -555,12 +516,13 @@ ShallowWrapper {
           <div
             className="mb-2"
             id="rich-text-editor-test"
+            tabIndex="-1"
           >
             <strong>
               Rich Text Editor Test
             </strong>
           </div>,
-          false,
+          undefined,
           <div
             aria-labelledby="rich-text-editor-test"
             className=""
@@ -601,6 +563,8 @@ ShallowWrapper {
             </strong>,
             "className": "mb-2",
             "id": "rich-text-editor-test",
+            "name": undefined,
+            "tabIndex": "-1",
           },
           "ref": null,
           "rendered": Object {
@@ -616,7 +580,7 @@ ShallowWrapper {
           },
           "type": "div",
         },
-        false,
+        undefined,
         Object {
           "instance": null,
           "key": undefined,
@@ -757,10 +721,11 @@ ShallowWrapper {
         <div
           className="mb-2"
           id="rich-text-editor-test"
+          tabIndex="-1"
         >
           Rich Text Editor Test
         </div>,
-        false,
+        undefined,
         <div
           aria-labelledby="rich-text-editor-test"
           className=""
@@ -799,12 +764,14 @@ ShallowWrapper {
           "children": "Rich Text Editor Test",
           "className": "mb-2",
           "id": "rich-text-editor-test",
+          "name": undefined,
+          "tabIndex": "-1",
         },
         "ref": null,
         "rendered": "Rich Text Editor Test",
         "type": "div",
       },
-      false,
+      undefined,
       Object {
         "instance": null,
         "key": undefined,
@@ -888,10 +855,11 @@ ShallowWrapper {
           <div
             className="mb-2"
             id="rich-text-editor-test"
+            tabIndex="-1"
           >
             Rich Text Editor Test
           </div>,
-          false,
+          undefined,
           <div
             aria-labelledby="rich-text-editor-test"
             className=""
@@ -930,12 +898,14 @@ ShallowWrapper {
             "children": "Rich Text Editor Test",
             "className": "mb-2",
             "id": "rich-text-editor-test",
+            "name": undefined,
+            "tabIndex": "-1",
           },
           "ref": null,
           "rendered": "Rich Text Editor Test",
           "type": "div",
         },
-        false,
+        undefined,
         Object {
           "instance": null,
           "key": undefined,
@@ -1080,12 +1050,13 @@ ShallowWrapper {
         <div
           className="mb-2"
           id="rich-text-editor-test"
+          tabIndex="-1"
         >
           <strong>
             Rich Text Editor Test
           </strong>
         </div>,
-        false,
+        undefined,
         <div
           aria-labelledby="rich-text-editor-test"
           className=""
@@ -1122,6 +1093,8 @@ ShallowWrapper {
           </strong>,
           "className": "mb-2",
           "id": "rich-text-editor-test",
+          "name": undefined,
+          "tabIndex": "-1",
         },
         "ref": null,
         "rendered": Object {
@@ -1137,7 +1110,7 @@ ShallowWrapper {
         },
         "type": "div",
       },
-      false,
+      undefined,
       Object {
         "instance": null,
         "key": undefined,
@@ -1206,12 +1179,13 @@ ShallowWrapper {
           <div
             className="mb-2"
             id="rich-text-editor-test"
+            tabIndex="-1"
           >
             <strong>
               Rich Text Editor Test
             </strong>
           </div>,
-          false,
+          undefined,
           <div
             aria-labelledby="rich-text-editor-test"
             className=""
@@ -1248,6 +1222,8 @@ ShallowWrapper {
             </strong>,
             "className": "mb-2",
             "id": "rich-text-editor-test",
+            "name": undefined,
+            "tabIndex": "-1",
           },
           "ref": null,
           "rendered": Object {
@@ -1263,7 +1239,7 @@ ShallowWrapper {
           },
           "type": "div",
         },
-        false,
+        undefined,
         Object {
           "instance": null,
           "key": undefined,

--- a/src/components/RichEditor/index.jsx
+++ b/src/components/RichEditor/index.jsx
@@ -45,9 +45,10 @@ class RichEditor extends React.Component {
       label,
       input: {
         value,
+        name,
       },
       meta: {
-        touched,
+        submitFailed,
         error,
       },
       disabled,
@@ -58,8 +59,8 @@ class RichEditor extends React.Component {
 
     return (
       <div className="form-group">
-        <div id={id} className="mb-2">{label}</div>
-        {touched && error &&
+        <div id={id} name={name} tabIndex="-1" className="mb-2">{label}</div>
+        {submitFailed && error &&
           <StatusAlert
             alertType="danger"
             message={error}
@@ -105,10 +106,12 @@ RichEditor.propTypes = {
   maxChars: PropTypes.number,
   input: PropTypes.shape({
     value: PropTypes.string,
+    name: PropTypes.string,
     onChange: PropTypes.func.isRequired,
   }).isRequired,
   meta: PropTypes.shape({
     touched: PropTypes.bool,
+    submitFailed: PropTypes.bool,
     error: PropTypes.string,
   }).isRequired,
   disabled: PropTypes.bool,

--- a/src/components/StaffList/StaffList.test.jsx
+++ b/src/components/StaffList/StaffList.test.jsx
@@ -51,6 +51,10 @@ const autoCompletePersonResponses = {
 
 const defaultProps = {
   input,
+  meta: {
+    submitFailed: false,
+    error: '',
+  },
   courseUuid: '11111111-1111-1111-1111-111111111111',
   courseRunKey: 'DemoX+TestCourse',
 };
@@ -96,6 +100,21 @@ describe('StaffList', () => {
 
   it('renders correctly with referred props', () => {
     const component = shallow(<StaffList {...referredProps} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly with an error after failed submission', () => {
+    const metaFailedProps = Object.assign(
+      {},
+      defaultProps,
+      {
+        meta: {
+          submitFailed: true,
+          error: 'This field is required',
+        },
+      },
+    );
+    const component = shallow(<StaffList {...metaFailedProps} />);
     expect(component).toMatchSnapshot();
   });
 

--- a/src/components/StaffList/__snapshots__/StaffList.test.jsx.snap
+++ b/src/components/StaffList/__snapshots__/StaffList.test.jsx.snap
@@ -32,6 +32,12 @@ ShallowWrapper {
         ],
       }
     }
+    meta={
+      Object {
+        "error": "",
+        "submitFailed": false,
+      }
+    }
     owners={Array []}
     sourceInfo={Object {}}
     stafferInfo={Object {}}
@@ -48,9 +54,10 @@ ShallowWrapper {
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "function",
+    "nodeType": "host",
     "props": Object {
       "children": Array [
+        false,
         <DragDropContext
           onDragEnd={[Function]}
         >
@@ -119,9 +126,12 @@ ShallowWrapper {
           />
         </label>,
       ],
+      "name": undefined,
+      "tabIndex": "-1",
     },
     "ref": null,
     "rendered": Array [
+      false,
       Object {
         "instance": null,
         "key": undefined,
@@ -281,15 +291,16 @@ ShallowWrapper {
         "type": "label",
       },
     ],
-    "type": Symbol(react.fragment),
+    "type": "div",
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
       "key": undefined,
-      "nodeType": "function",
+      "nodeType": "host",
       "props": Object {
         "children": Array [
+          false,
           <DragDropContext
             onDragEnd={[Function]}
           >
@@ -358,9 +369,12 @@ ShallowWrapper {
             />
           </label>,
         ],
+        "name": undefined,
+        "tabIndex": "-1",
       },
       "ref": null,
       "rendered": Array [
+        false,
         Object {
           "instance": null,
           "key": undefined,
@@ -520,7 +534,619 @@ ShallowWrapper {
           "type": "label",
         },
       ],
-      "type": Symbol(react.fragment),
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+  Symbol(enzyme.__childContext__): null,
+}
+`;
+
+exports[`StaffList renders correctly with an error after failed submission 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <StaffList
+    courseRunKey="DemoX+TestCourse"
+    courseUuid="11111111-1111-1111-1111-111111111111"
+    disabled={false}
+    input={
+      Object {
+        "onChange": [MockFunction],
+        "value": Array [
+          Object {
+            "family_name": "Last",
+            "given_name": "First",
+            "profile_image_url": "/media/people/profile_images/6f23f2f8-10dd-454a-8497-2ba972c980c4-a411afec9477.jpeg",
+            "uuid": "6f23f2f8-10dd-454a-8497-2ba972c980c4",
+          },
+          Object {
+            "family_name": null,
+            "given_name": "Pippa",
+            "profile_image_url": "/media/people/profile_images/17d0e2c0-9a02-421b-93bf-d081339090cc-68912d27b6e7.jpeg",
+            "uuid": "17d0e2c0-9a02-421b-93bf-d081339090cc",
+          },
+          Object {
+            "family_name": "Grohl",
+            "given_name": "Dave",
+            "profile_image_url": "/media/people/profile_images/2aba6189-ad7e-45a8-b269-bea071b80391-11df6812f839.png",
+            "uuid": "2aba6189-ad7e-45a8-b269-bea071b80391",
+          },
+        ],
+      }
+    }
+    meta={
+      Object {
+        "error": "This field is required",
+        "submitFailed": true,
+      }
+    }
+    owners={Array []}
+    sourceInfo={Object {}}
+    stafferInfo={Object {}}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <StatusAlert
+          alertType="danger"
+          className=""
+          dismissible={false}
+          iconClassNames={Array []}
+          message="This field is required"
+          onClose={[Function]}
+          title={null}
+        />,
+        <DragDropContext
+          onDragEnd={[Function]}
+        >
+          <Connect(Droppable)
+            direction="vertical"
+            droppableId="StaffList"
+            ignoreContainerClipping={false}
+            isCombineEnabled={false}
+            isDropDisabled={false}
+            type="DEFAULT"
+          >
+            [Function]
+          </Connect(Droppable)>
+        </DragDropContext>,
+        <label
+          className="w-100"
+          htmlFor="staff-search"
+          id="label-staff-search"
+          onKeyDown={[Function]}
+        >
+          <strong>
+            Search or add new instructor:
+          </strong>
+          <Autosuggest
+            alwaysRenderSuggestions={false}
+            focusInputOnSuggestionClick={true}
+            getSuggestionValue={[Function]}
+            highlightFirstSuggestion={false}
+            id="staff-search"
+            inputProps={
+              Object {
+                "className": "form-control",
+                "disabled": false,
+                "onChange": [Function],
+                "placeholder": "",
+                "type": "text",
+                "value": "",
+              }
+            }
+            multiSection={false}
+            onSuggestionSelected={[Function]}
+            onSuggestionsClearRequested={[Function]}
+            onSuggestionsFetchRequested={[Function]}
+            renderSuggestion={[Function]}
+            renderSuggestionsContainer={[Function]}
+            shouldRenderSuggestions={[Function]}
+            suggestions={Array []}
+            theme={
+              Object {
+                "container": "react-autosuggest__container",
+                "containerOpen": "react-autosuggest__container--open",
+                "input": "react-autosuggest__input",
+                "inputFocused": "react-autosuggest__input--focused",
+                "inputOpen": "react-autosuggest__input--open",
+                "sectionContainer": "react-autosuggest__section-container",
+                "sectionContainerFirst": "react-autosuggest__section-container--first",
+                "sectionTitle": "react-autosuggest__section-title",
+                "suggestion": "react-autosuggest__suggestion",
+                "suggestionFirst": "react-autosuggest__suggestion--first",
+                "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                "suggestionsContainer": "react-autosuggest__suggestions-container",
+                "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                "suggestionsList": "react-autosuggest__suggestions-list",
+              }
+            }
+          />
+        </label>,
+      ],
+      "name": undefined,
+      "tabIndex": "-1",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "alertType": "danger",
+          "className": "",
+          "dismissible": false,
+          "iconClassNames": Array [],
+          "message": "This field is required",
+          "onClose": [Function],
+          "title": null,
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <Connect(Droppable)
+            direction="vertical"
+            droppableId="StaffList"
+            ignoreContainerClipping={false}
+            isCombineEnabled={false}
+            isDropDisabled={false}
+            type="DEFAULT"
+          >
+            [Function]
+          </Connect(Droppable)>,
+          "onDragEnd": [Function],
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": [Function],
+            "direction": "vertical",
+            "droppableId": "StaffList",
+            "ignoreContainerClipping": false,
+            "isCombineEnabled": false,
+            "isDropDisabled": false,
+            "type": "DEFAULT",
+          },
+          "ref": null,
+          "rendered": [Function],
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <strong>
+              Search or add new instructor:
+            </strong>,
+            <Autosuggest
+              alwaysRenderSuggestions={false}
+              focusInputOnSuggestionClick={true}
+              getSuggestionValue={[Function]}
+              highlightFirstSuggestion={false}
+              id="staff-search"
+              inputProps={
+                Object {
+                  "className": "form-control",
+                  "disabled": false,
+                  "onChange": [Function],
+                  "placeholder": "",
+                  "type": "text",
+                  "value": "",
+                }
+              }
+              multiSection={false}
+              onSuggestionSelected={[Function]}
+              onSuggestionsClearRequested={[Function]}
+              onSuggestionsFetchRequested={[Function]}
+              renderSuggestion={[Function]}
+              renderSuggestionsContainer={[Function]}
+              shouldRenderSuggestions={[Function]}
+              suggestions={Array []}
+              theme={
+                Object {
+                  "container": "react-autosuggest__container",
+                  "containerOpen": "react-autosuggest__container--open",
+                  "input": "react-autosuggest__input",
+                  "inputFocused": "react-autosuggest__input--focused",
+                  "inputOpen": "react-autosuggest__input--open",
+                  "sectionContainer": "react-autosuggest__section-container",
+                  "sectionContainerFirst": "react-autosuggest__section-container--first",
+                  "sectionTitle": "react-autosuggest__section-title",
+                  "suggestion": "react-autosuggest__suggestion",
+                  "suggestionFirst": "react-autosuggest__suggestion--first",
+                  "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                  "suggestionsContainer": "react-autosuggest__suggestions-container",
+                  "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                  "suggestionsList": "react-autosuggest__suggestions-list",
+                }
+              }
+            />,
+          ],
+          "className": "w-100",
+          "htmlFor": "staff-search",
+          "id": "label-staff-search",
+          "onKeyDown": [Function],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Search or add new instructor:",
+            },
+            "ref": null,
+            "rendered": "Search or add new instructor:",
+            "type": "strong",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "alwaysRenderSuggestions": false,
+              "focusInputOnSuggestionClick": true,
+              "getSuggestionValue": [Function],
+              "highlightFirstSuggestion": false,
+              "id": "staff-search",
+              "inputProps": Object {
+                "className": "form-control",
+                "disabled": false,
+                "onChange": [Function],
+                "placeholder": "",
+                "type": "text",
+                "value": "",
+              },
+              "multiSection": false,
+              "onSuggestionSelected": [Function],
+              "onSuggestionsClearRequested": [Function],
+              "onSuggestionsFetchRequested": [Function],
+              "renderSuggestion": [Function],
+              "renderSuggestionsContainer": [Function],
+              "shouldRenderSuggestions": [Function],
+              "suggestions": Array [],
+              "theme": Object {
+                "container": "react-autosuggest__container",
+                "containerOpen": "react-autosuggest__container--open",
+                "input": "react-autosuggest__input",
+                "inputFocused": "react-autosuggest__input--focused",
+                "inputOpen": "react-autosuggest__input--open",
+                "sectionContainer": "react-autosuggest__section-container",
+                "sectionContainerFirst": "react-autosuggest__section-container--first",
+                "sectionTitle": "react-autosuggest__section-title",
+                "suggestion": "react-autosuggest__suggestion",
+                "suggestionFirst": "react-autosuggest__suggestion--first",
+                "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                "suggestionsContainer": "react-autosuggest__suggestions-container",
+                "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                "suggestionsList": "react-autosuggest__suggestions-list",
+              },
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+        ],
+        "type": "label",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <StatusAlert
+            alertType="danger"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="This field is required"
+            onClose={[Function]}
+            title={null}
+          />,
+          <DragDropContext
+            onDragEnd={[Function]}
+          >
+            <Connect(Droppable)
+              direction="vertical"
+              droppableId="StaffList"
+              ignoreContainerClipping={false}
+              isCombineEnabled={false}
+              isDropDisabled={false}
+              type="DEFAULT"
+            >
+              [Function]
+            </Connect(Droppable)>
+          </DragDropContext>,
+          <label
+            className="w-100"
+            htmlFor="staff-search"
+            id="label-staff-search"
+            onKeyDown={[Function]}
+          >
+            <strong>
+              Search or add new instructor:
+            </strong>
+            <Autosuggest
+              alwaysRenderSuggestions={false}
+              focusInputOnSuggestionClick={true}
+              getSuggestionValue={[Function]}
+              highlightFirstSuggestion={false}
+              id="staff-search"
+              inputProps={
+                Object {
+                  "className": "form-control",
+                  "disabled": false,
+                  "onChange": [Function],
+                  "placeholder": "",
+                  "type": "text",
+                  "value": "",
+                }
+              }
+              multiSection={false}
+              onSuggestionSelected={[Function]}
+              onSuggestionsClearRequested={[Function]}
+              onSuggestionsFetchRequested={[Function]}
+              renderSuggestion={[Function]}
+              renderSuggestionsContainer={[Function]}
+              shouldRenderSuggestions={[Function]}
+              suggestions={Array []}
+              theme={
+                Object {
+                  "container": "react-autosuggest__container",
+                  "containerOpen": "react-autosuggest__container--open",
+                  "input": "react-autosuggest__input",
+                  "inputFocused": "react-autosuggest__input--focused",
+                  "inputOpen": "react-autosuggest__input--open",
+                  "sectionContainer": "react-autosuggest__section-container",
+                  "sectionContainerFirst": "react-autosuggest__section-container--first",
+                  "sectionTitle": "react-autosuggest__section-title",
+                  "suggestion": "react-autosuggest__suggestion",
+                  "suggestionFirst": "react-autosuggest__suggestion--first",
+                  "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                  "suggestionsContainer": "react-autosuggest__suggestions-container",
+                  "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                  "suggestionsList": "react-autosuggest__suggestions-list",
+                }
+              }
+            />
+          </label>,
+        ],
+        "name": undefined,
+        "tabIndex": "-1",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "alertType": "danger",
+            "className": "",
+            "dismissible": false,
+            "iconClassNames": Array [],
+            "message": "This field is required",
+            "onClose": [Function],
+            "title": null,
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": <Connect(Droppable)
+              direction="vertical"
+              droppableId="StaffList"
+              ignoreContainerClipping={false}
+              isCombineEnabled={false}
+              isDropDisabled={false}
+              type="DEFAULT"
+            >
+              [Function]
+            </Connect(Droppable)>,
+            "onDragEnd": [Function],
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": [Function],
+              "direction": "vertical",
+              "droppableId": "StaffList",
+              "ignoreContainerClipping": false,
+              "isCombineEnabled": false,
+              "isDropDisabled": false,
+              "type": "DEFAULT",
+            },
+            "ref": null,
+            "rendered": [Function],
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <strong>
+                Search or add new instructor:
+              </strong>,
+              <Autosuggest
+                alwaysRenderSuggestions={false}
+                focusInputOnSuggestionClick={true}
+                getSuggestionValue={[Function]}
+                highlightFirstSuggestion={false}
+                id="staff-search"
+                inputProps={
+                  Object {
+                    "className": "form-control",
+                    "disabled": false,
+                    "onChange": [Function],
+                    "placeholder": "",
+                    "type": "text",
+                    "value": "",
+                  }
+                }
+                multiSection={false}
+                onSuggestionSelected={[Function]}
+                onSuggestionsClearRequested={[Function]}
+                onSuggestionsFetchRequested={[Function]}
+                renderSuggestion={[Function]}
+                renderSuggestionsContainer={[Function]}
+                shouldRenderSuggestions={[Function]}
+                suggestions={Array []}
+                theme={
+                  Object {
+                    "container": "react-autosuggest__container",
+                    "containerOpen": "react-autosuggest__container--open",
+                    "input": "react-autosuggest__input",
+                    "inputFocused": "react-autosuggest__input--focused",
+                    "inputOpen": "react-autosuggest__input--open",
+                    "sectionContainer": "react-autosuggest__section-container",
+                    "sectionContainerFirst": "react-autosuggest__section-container--first",
+                    "sectionTitle": "react-autosuggest__section-title",
+                    "suggestion": "react-autosuggest__suggestion",
+                    "suggestionFirst": "react-autosuggest__suggestion--first",
+                    "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                    "suggestionsContainer": "react-autosuggest__suggestions-container",
+                    "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                    "suggestionsList": "react-autosuggest__suggestions-list",
+                  }
+                }
+              />,
+            ],
+            "className": "w-100",
+            "htmlFor": "staff-search",
+            "id": "label-staff-search",
+            "onKeyDown": [Function],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Search or add new instructor:",
+              },
+              "ref": null,
+              "rendered": "Search or add new instructor:",
+              "type": "strong",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "alwaysRenderSuggestions": false,
+                "focusInputOnSuggestionClick": true,
+                "getSuggestionValue": [Function],
+                "highlightFirstSuggestion": false,
+                "id": "staff-search",
+                "inputProps": Object {
+                  "className": "form-control",
+                  "disabled": false,
+                  "onChange": [Function],
+                  "placeholder": "",
+                  "type": "text",
+                  "value": "",
+                },
+                "multiSection": false,
+                "onSuggestionSelected": [Function],
+                "onSuggestionsClearRequested": [Function],
+                "onSuggestionsFetchRequested": [Function],
+                "renderSuggestion": [Function],
+                "renderSuggestionsContainer": [Function],
+                "shouldRenderSuggestions": [Function],
+                "suggestions": Array [],
+                "theme": Object {
+                  "container": "react-autosuggest__container",
+                  "containerOpen": "react-autosuggest__container--open",
+                  "input": "react-autosuggest__input",
+                  "inputFocused": "react-autosuggest__input--focused",
+                  "inputOpen": "react-autosuggest__input--open",
+                  "sectionContainer": "react-autosuggest__section-container",
+                  "sectionContainerFirst": "react-autosuggest__section-container--first",
+                  "sectionTitle": "react-autosuggest__section-title",
+                  "suggestion": "react-autosuggest__suggestion",
+                  "suggestionFirst": "react-autosuggest__suggestion--first",
+                  "suggestionHighlighted": "react-autosuggest__suggestion--highlighted",
+                  "suggestionsContainer": "react-autosuggest__suggestions-container",
+                  "suggestionsContainerOpen": "react-autosuggest__suggestions-container--open",
+                  "suggestionsList": "react-autosuggest__suggestions-list",
+                },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+          ],
+          "type": "label",
+        },
+      ],
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {
@@ -619,6 +1245,12 @@ ShallowWrapper {
         ],
       }
     }
+    meta={
+      Object {
+        "error": "",
+        "submitFailed": false,
+      }
+    }
     owners={Array []}
     sourceInfo={
       Object {
@@ -648,9 +1280,10 @@ ShallowWrapper {
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "function",
+    "nodeType": "host",
     "props": Object {
       "children": Array [
+        false,
         <DragDropContext
           onDragEnd={[Function]}
         >
@@ -719,9 +1352,12 @@ ShallowWrapper {
           />
         </label>,
       ],
+      "name": undefined,
+      "tabIndex": "-1",
     },
     "ref": null,
     "rendered": Array [
+      false,
       Object {
         "instance": null,
         "key": undefined,
@@ -881,15 +1517,16 @@ ShallowWrapper {
         "type": "label",
       },
     ],
-    "type": Symbol(react.fragment),
+    "type": "div",
   },
   Symbol(enzyme.__nodes__): Array [
     Object {
       "instance": null,
       "key": undefined,
-      "nodeType": "function",
+      "nodeType": "host",
       "props": Object {
         "children": Array [
+          false,
           <DragDropContext
             onDragEnd={[Function]}
           >
@@ -958,9 +1595,12 @@ ShallowWrapper {
             />
           </label>,
         ],
+        "name": undefined,
+        "tabIndex": "-1",
       },
       "ref": null,
       "rendered": Array [
+        false,
         Object {
           "instance": null,
           "key": undefined,
@@ -1120,7 +1760,7 @@ ShallowWrapper {
           "type": "label",
         },
       ],
-      "type": Symbol(react.fragment),
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/src/components/StaffList/index.jsx
+++ b/src/components/StaffList/index.jsx
@@ -10,6 +10,7 @@ import DiscoveryDataApiService from '../../data/services/DiscoveryDataApiService
 import { Staffer, getStafferName } from '../Staffer';
 import sourceInfo from '../../data/actions/sourceInfo';
 import store from '../../data/store';
+import StatusAlert from '../StatusAlert';
 
 
 class StaffList extends React.Component {
@@ -222,9 +223,18 @@ class StaffList extends React.Component {
       suggestions,
       searchString,
     } = this.state;
+
     const {
       disabled,
+      meta: {
+        submitFailed,
+        error,
+      },
+      input: {
+        name,
+      },
     } = this.props;
+
     const inputProps = {
       placeholder: '',
       value: searchString,
@@ -235,7 +245,14 @@ class StaffList extends React.Component {
     };
 
     return (
-      <React.Fragment>
+      // Set tabIndex to -1 to allow programmatic shifting of focus for validation
+      <div name={name} tabIndex="-1">
+        {submitFailed && error &&
+          <StatusAlert
+            alertType="danger"
+            message={error}
+          />
+        }
         <DragDropContext onDragEnd={this.onDragEnd}>
           <Droppable droppableId="StaffList" direction="vertical">
             {provided => (
@@ -283,7 +300,7 @@ class StaffList extends React.Component {
           />
         </label>
         {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */}
-      </React.Fragment>
+      </div>
     );
   }
 }
@@ -300,6 +317,7 @@ StaffList.propTypes = {
       })),
     ]).isRequired,
     onChange: PropTypes.func.isRequired,
+    name: PropTypes.string,
   }).isRequired,
   disabled: PropTypes.bool,
   owners: PropTypes.arrayOf(PropTypes.shape({})),
@@ -311,6 +329,10 @@ StaffList.propTypes = {
   sourceInfo: PropTypes.shape({
     referringRun: PropTypes.string,
   }),
+  meta: PropTypes.shape({
+    submitFailed: PropTypes.bool,
+    error: PropTypes.string,
+  }).isRequired,
 };
 
 StaffList.defaultProps = {

--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -12,9 +12,8 @@ import RenderSelectField from '../RenderSelectField';
 import RichEditor from '../../components/RichEditor';
 import FieldLabel from '../FieldLabel';
 import ButtonToolbar from '../ButtonToolbar';
+import { basicValidate } from '../../utils/validation';
 
-
-const basicValidate = value => (value ? undefined : 'This field is required');
 
 const extractOrgChoices = (stafferOptions) => {
   const { data = {} } = stafferOptions;

--- a/src/components/StafferPage/StafferForm.test.jsx
+++ b/src/components/StafferPage/StafferForm.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { extractOrgChoices, BaseStafferForm, basicValidate } from './StafferForm';
+import { extractOrgChoices, BaseStafferForm } from './StafferForm';
 
 
 const stafferOptions = {
@@ -165,23 +165,5 @@ describe('extractOrgChoices', () => {
   it('extracts empty list of org choices from junk options', () => {
     const choices = extractOrgChoices({ junk: 'junk' });
     expect(choices).toEqual([]);
-  });
-});
-
-describe('basicValidate', () => {
-  it('returns a validation message for falsey values', () => {
-    const falseyValues = [0, '', undefined, null];
-
-    falseyValues.forEach((value) => {
-      expect(basicValidate(value)).toEqual('This field is required');
-    });
-  });
-
-  it('returns undefined for truthy values', () => {
-    const truthyValues = [1, 'test', { key: 'key value' }];
-
-    truthyValues.forEach((value) => {
-      expect(basicValidate(value)).toEqual(undefined);
-    });
   });
 });

--- a/src/containers/EditCourse/index.jsx
+++ b/src/containers/EditCourse/index.jsx
@@ -12,6 +12,7 @@ const mapStateToProps = state => ({
   courseRunOptions: state.courseRunOptions,
   stafferInfo: state.stafferInfo,
   sourceInfo: state.sourceInfo,
+  courseSubmitInfo: state.courseSubmitInfo,
 });
 
 const mapDispatchToProps = {

--- a/src/data/actions/courseSubmitInfo.js
+++ b/src/data/actions/courseSubmitInfo.js
@@ -1,0 +1,5 @@
+import COURSE_SUBMIT_INFO from '../constants/courseSubmitInfo';
+
+export default function courseSubmitInfo(targetRun = null) {
+  return { type: COURSE_SUBMIT_INFO, targetRun };
+}

--- a/src/data/actions/courseSubmitInfo.test.js
+++ b/src/data/actions/courseSubmitInfo.test.js
@@ -1,0 +1,27 @@
+import courseSubmitInfo from './courseSubmitInfo';
+import COURSE_SUBMIT_INFO from '../constants/courseSubmitInfo';
+
+
+describe('courseSubmitInfo actions', () => {
+  const targetRun = {
+    key: 'edX101+DemoX',
+  };
+
+  it('handles submitting from the course page without a target run', () => {
+    const expectedAction = {
+      type: COURSE_SUBMIT_INFO,
+      targetRun: null,
+    };
+
+    expect(courseSubmitInfo()).toEqual(expectedAction);
+  });
+
+  it('handles submitting from the course page with a target run', () => {
+    const expectedAction = {
+      type: COURSE_SUBMIT_INFO,
+      targetRun,
+    };
+
+    expect(courseSubmitInfo(targetRun)).toEqual(expectedAction);
+  });
+});

--- a/src/data/constants/courseSubmitInfo.js
+++ b/src/data/constants/courseSubmitInfo.js
@@ -1,0 +1,1 @@
+export default 'COURSE_SUBMIT_INFO';

--- a/src/data/reducers/courseSubmitInfo.js
+++ b/src/data/reducers/courseSubmitInfo.js
@@ -1,0 +1,19 @@
+import COURSE_SUBMIT_INFO from '../constants/courseSubmitInfo';
+
+
+const initialState = {
+  targetRun: null,
+};
+
+function courseSubmitInfo(state = initialState, action) {
+  switch (action.type) {
+    case COURSE_SUBMIT_INFO:
+      return Object.assign({}, state, {
+        targetRun: action.targetRun,
+      });
+    default:
+      return state;
+  }
+}
+
+export default courseSubmitInfo;

--- a/src/data/reducers/courseSubmitInfo.test.js
+++ b/src/data/reducers/courseSubmitInfo.test.js
@@ -1,0 +1,26 @@
+import courseSubmitInfoReducer from './courseSubmitInfo';
+import courseSubmitInfo from '../actions/courseSubmitInfo';
+
+
+describe('courseSubmitInfo reducer', () => {
+  let initalState;
+
+  beforeEach(() => {
+    initalState = {
+      targetRun: null,
+    };
+  });
+
+  it('initial state is valid', () => {
+    expect(courseSubmitInfoReducer(undefined, {})).toEqual({ targetRun: null });
+  });
+
+  it('courseSubmitInfo action works', () => {
+    const targetRun = {
+      key: 'edX101+DemoX',
+    };
+
+    expect(courseSubmitInfoReducer(initalState, courseSubmitInfo(targetRun)))
+      .toEqual({ targetRun });
+  });
+});

--- a/src/data/reducers/index.js
+++ b/src/data/reducers/index.js
@@ -10,6 +10,7 @@ import stafferOptions from './stafferOptions';
 import stafferInfo from './stafferInfo';
 import courseRunOptions from './courseRunOptions';
 import sourceInfo from './sourceInfo';
+import courseSubmitInfo from './courseSubmitInfo';
 
 const identityReducer = (state) => {
   const newState = { ...state };
@@ -30,4 +31,5 @@ export default history => combineReducers({
   form: formReducer,
   table,
   sourceInfo,
+  courseSubmitInfo,
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 import qs from 'query-string';
 
-import history from './data/history';
+import history from '../data/history';
 
 
 const updateUrl = (queryOptions) => {

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,4 +1,4 @@
-import * as utils from './utils';
+import * as utils from '.';
 
 
 describe('jsonDeepCopy', () => {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -29,33 +29,33 @@ const basicValidate = value => (value ? undefined : requiredMessage);
  * @returns {string} - The first field name with a validation error
  */
 const getFieldName = (errors) => {
-  if (errors) {
-    // Get the first field name and associated info
-    let [fieldName, otherInfo] = Object.entries(errors)[0];
-
-    // Parse field arrays for nested field errors
-    while (Array.isArray(otherInfo)) {
-      // Deep copy otherInfo to avoid modifying it in the loop
-      const otherInfoCopy = jsonDeepCopy(otherInfo);
-      for (let i = 0; i < otherInfoCopy.length; i += 1) {
-        const nestedErrors = otherInfoCopy[i];
-
-        if (nestedErrors) {
-          // Get the first nested field name and associated info
-          const [nestedFieldName, nestedInfo] = Object.entries(nestedErrors)[0];
-
-          // Reset otherInfo to the new nestedInfo to keep parsing further down
-          otherInfo = nestedInfo;
-          // Fields within field arrays have names like: course_runs[1].staff
-          fieldName = `${fieldName}[${i}].${nestedFieldName}`;
-        }
-      }
-    }
-
-    return fieldName;
+  if (!errors) {
+    return null;
   }
 
-  return null;
+  // Get the first field name and associated info
+  let [fieldName, otherInfo] = Object.entries(errors)[0];
+
+  // Parse field arrays for nested field errors
+  while (Array.isArray(otherInfo)) {
+    // Deep copy otherInfo to avoid modifying it in the loop
+    const otherInfoCopy = jsonDeepCopy(otherInfo);
+    for (let i = 0; i < otherInfoCopy.length; i += 1) {
+      const nestedErrors = otherInfoCopy[i];
+
+      if (nestedErrors) {
+        // Get the first nested field name and associated info
+        const [nestedFieldName, nestedInfo] = Object.entries(nestedErrors)[0];
+
+        // Reset otherInfo to the new nestedInfo to keep parsing further down
+        otherInfo = nestedInfo;
+        // Fields within field arrays have names like: course_runs[1].staff
+        fieldName = `${fieldName}[${i}].${nestedFieldName}`;
+      }
+    }
+  }
+
+  return fieldName;
 };
 
 // Focus on the first element that has validation errors
@@ -69,48 +69,48 @@ const handleCourseEditFail = (errors) => {
 const editCourseValidate = (values, props) => {
   const { targetRun } = props;
 
-  if (targetRun && targetRun.status !== PUBLISHED) {
-    const errors = {};
-
-    // Validate all the fields required for submission at the top level of the form
-    const courseRequiredFields = ['short_description', 'full_description', 'outcome'];
-    courseRequiredFields.forEach((fieldName) => {
-      const value = values[fieldName];
-      if (!value) {
-        errors[fieldName] = requiredMessage;
-      }
-    });
-
-    // Validate all the fields required for submission in the submitting course run
-    errors.course_runs = [];
-    values.course_runs.forEach((run) => {
-      const { key: targetKey } = targetRun;
-      const isSubmittingRun = run.key === targetKey;
-      if (isSubmittingRun) {
-        const runRequiredFields = ['transcript_languages', 'staff'];
-        const runErrors = {};
-        runRequiredFields.forEach((fieldName) => {
-          const value = run[fieldName];
-          if (value.length < 1) {
-            if (fieldName === 'transcript_languages') {
-              // redux-form field arrays expect errors to be in this shape
-              runErrors[fieldName] = { _error: requiredMessage };
-            } else {
-              runErrors[fieldName] = 'This field is required';
-            }
-          }
-        });
-
-        errors.course_runs.push(runErrors);
-      } else {
-        errors.course_runs.push(null);
-      }
-    });
-
-    return errors;
+  if (!targetRun || targetRun.status === PUBLISHED) {
+    return undefined;
   }
 
-  return undefined;
+  const errors = {};
+
+  // Validate all the fields required for submission at the top level of the form
+  const courseRequiredFields = ['short_description', 'full_description', 'outcome'];
+  courseRequiredFields.forEach((fieldName) => {
+    const value = values[fieldName];
+    if (!value) {
+      errors[fieldName] = requiredMessage;
+    }
+  });
+
+  // Validate all the fields required for submission in the submitting course run
+  errors.course_runs = [];
+  values.course_runs.forEach((run) => {
+    const { key: targetKey } = targetRun;
+    const isSubmittingRun = run.key === targetKey;
+    if (isSubmittingRun) {
+      const runRequiredFields = ['transcript_languages', 'staff'];
+      const runErrors = {};
+      runRequiredFields.forEach((fieldName) => {
+        const value = run[fieldName];
+        if (value.length < 1) {
+          if (fieldName === 'transcript_languages') {
+            // redux-form field arrays expect errors to be in this shape
+            runErrors[fieldName] = { _error: requiredMessage };
+          } else {
+            runErrors[fieldName] = 'This field is required';
+          }
+        }
+      });
+
+      errors.course_runs.push(runErrors);
+    } else {
+      errors.course_runs.push(null);
+    }
+  });
+
+  return errors;
 };
 
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,123 @@
+import { jsonDeepCopy } from '.';
+import { PUBLISHED } from '../data/constants';
+
+
+const requiredMessage = 'This field is required';
+
+// Basic validation that ensures some value was entered
+const basicValidate = value => (value ? undefined : requiredMessage);
+
+/**
+ * Iterates through errors on a form and returns the first field name with an error.
+ *
+ * @param {?object} errors - Object with keys giving the field names with errors in a form like:
+ *   {
+ *     short_description: "Required",
+ *     outcome: "Required",
+ *     course_runs: [
+ *       null,
+ *       {
+ *         transcript_languages: {
+ *           _error: "Required",
+ *         },
+ *         staff: "Required"
+ *       }
+ *     ]
+ *   };
+ *   The param will be null if there are no errors.
+ *
+ * @returns {string} - The first field name with a validation error
+ */
+const getFieldName = (errors) => {
+  if (errors) {
+    // Get the first field name and associated info
+    let [fieldName, otherInfo] = Object.entries(errors)[0];
+
+    // Parse field arrays for nested field errors
+    while (Array.isArray(otherInfo)) {
+      // Deep copy otherInfo to avoid modifying it in the loop
+      const otherInfoCopy = jsonDeepCopy(otherInfo);
+      for (let i = 0; i < otherInfoCopy.length; i += 1) {
+        const nestedErrors = otherInfoCopy[i];
+
+        if (nestedErrors) {
+          // Get the first nested field name and associated info
+          const [nestedFieldName, nestedInfo] = Object.entries(nestedErrors)[0];
+
+          // Reset otherInfo to the new nestedInfo to keep parsing further down
+          otherInfo = nestedInfo;
+          // Fields within field arrays have names like: course_runs[1].staff
+          fieldName = `${fieldName}[${i}].${nestedFieldName}`;
+        }
+      }
+    }
+
+    return fieldName;
+  }
+
+  return null;
+};
+
+// Focus on the first element that has validation errors
+const handleCourseEditFail = (errors) => {
+  const fieldName = getFieldName(errors);
+  if (fieldName) {
+    document.getElementsByName(fieldName)[0].focus();
+  }
+};
+
+const editCourseValidate = (values, props) => {
+  const { targetRun } = props;
+
+  if (targetRun && targetRun.status !== PUBLISHED) {
+    const errors = {};
+
+    // Validate all the fields required for submission at the top level of the form
+    const courseRequiredFields = ['short_description', 'full_description', 'outcome'];
+    courseRequiredFields.forEach((fieldName) => {
+      const value = values[fieldName];
+      if (!value) {
+        errors[fieldName] = requiredMessage;
+      }
+    });
+
+    // Validate all the fields required for submission in the submitting course run
+    errors.course_runs = [];
+    values.course_runs.forEach((run) => {
+      const { key: targetKey } = targetRun || {};
+      const isSubmittingRun = run.key === targetKey;
+      if (isSubmittingRun) {
+        const runRequiredFields = ['transcript_languages', 'staff'];
+        const runErrors = {};
+        runRequiredFields.forEach((fieldName) => {
+          const value = run[fieldName];
+          if (value.length < 1) {
+            if (fieldName === 'transcript_languages') {
+              // redux-form field arrays expect errors to be in this shape
+              runErrors[fieldName] = { _error: requiredMessage };
+            } else {
+              runErrors[fieldName] = 'This field is required';
+            }
+          }
+        });
+
+        errors.course_runs.push(runErrors);
+      } else {
+        errors.course_runs.push(null);
+      }
+    });
+
+    return errors;
+  }
+
+  return undefined;
+};
+
+
+export {
+  requiredMessage,
+  basicValidate,
+  getFieldName,
+  handleCourseEditFail,
+  editCourseValidate,
+};

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -84,7 +84,7 @@ const editCourseValidate = (values, props) => {
     // Validate all the fields required for submission in the submitting course run
     errors.course_runs = [];
     values.course_runs.forEach((run) => {
-      const { key: targetKey } = targetRun || {};
+      const { key: targetKey } = targetRun;
       const isSubmittingRun = run.key === targetKey;
       if (isSubmittingRun) {
         const runRequiredFields = ['transcript_languages', 'staff'];

--- a/src/utils/validation.test.js
+++ b/src/utils/validation.test.js
@@ -1,0 +1,81 @@
+import {
+  requiredMessage,
+  basicValidate,
+  getFieldName,
+} from './validation';
+
+describe('basicValidate', () => {
+  it('returns a validation message for falsey values', () => {
+    const falseyValues = [0, '', undefined, null];
+
+    falseyValues.forEach((value) => {
+      expect(basicValidate(value)).toEqual(requiredMessage);
+    });
+  });
+
+  it('returns undefined for truthy values', () => {
+    const truthyValues = [1, 'test', { key: 'key value' }];
+
+    truthyValues.forEach((value) => {
+      expect(basicValidate(value)).toEqual(undefined);
+    });
+  });
+});
+
+describe('getFieldName', () => {
+  it('returns null if there are no errors', () => {
+    expect(getFieldName(undefined)).toEqual(null);
+  });
+
+  it('returns the first field name in errors for simple fields', () => {
+    const errors = {
+      short_description: 'This field is required',
+      full_description: 'This field is required',
+    };
+    expect(getFieldName(errors)).toEqual('short_description');
+  });
+
+  it('returns the first full field name in errors for field arrays, ignoring null errors', () => {
+    const errors = {
+      course_runs: [
+        null,
+        {
+          transcript_languages: {
+            _error: 'This field is required',
+          },
+          staff: 'This field is required',
+        },
+      ],
+      full_description: 'This field is required',
+    };
+    expect(getFieldName(errors)).toEqual('course_runs[1].transcript_languages');
+  });
+
+  it('returns the first full field name in errors for deeply nested fields', () => {
+    const errors = {
+      course_runs: [
+        null,
+        {
+          deep_property: [
+            null,
+            null,
+            {
+              deeper_property: [
+                {
+                  deepest_property: 'This field is required',
+                },
+              ],
+            },
+          ],
+          transcript_languages: {
+            _error: 'This field is required',
+          },
+          staff: 'This field is required',
+        },
+      ],
+      full_description: 'This field is required',
+    };
+
+    expect(getFieldName(errors)).toEqual('course_runs[1].deep_property[2].deeper_property[0].deepest_property');
+  });
+});


### PR DESCRIPTION
DISCO-878

Note: we don't pass through props on fields within field arrays which rely on `meta` to avoid "polluting" the field meta info with higher up meta information