### PR TITLE
Adding tooltips to the instructor create/edit page

### DIFF
--- a/src/components/StafferPage/StafferForm.jsx
+++ b/src/components/StafferPage/StafferForm.jsx
@@ -45,7 +45,22 @@ const BaseStafferForm = ({
         <Field
           name="profile_image.medium.url"
           component={ImageUpload}
-          label={<FieldLabel text="Image" required />}
+          label={
+            <FieldLabel
+              id="image.label"
+              text="Image"
+              helpText={
+                <div>
+                  <p>Image Requirements:</p>
+                  <ul>
+                    <li>The image dimensions must be 110×110.</li>
+                    <li>The image size must be less than 256KB.</li>
+                  </ul>
+                </div>
+              }
+              required
+            />
+          }
           id="profile_image"
           className="staffer-image"
           required={isCreateForm}
@@ -68,7 +83,24 @@ const BaseStafferForm = ({
           name="position.title"
           component={RenderInputTextField}
           type="text"
-          label={<FieldLabel text="Position" required />}
+          label={
+            <FieldLabel
+              id="position.label"
+              text="Position"
+              helpText={
+                <div>
+                  <p>Your role at your organization.</p>
+                  <p><b>Examples:</b></p>
+                  <ul>
+                    <li>Professor</li>
+                    <li>Content Developer</li>
+                    <li>Director</li>
+                  </ul>
+                </div>
+              }
+              required
+            />
+          }
           required
         />
         <Field

--- a/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
+++ b/src/components/StafferPage/__snapshots__/StafferForm.test.jsx.snap
@@ -65,8 +65,22 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -112,8 +126,30 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -252,8 +288,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -299,8 +349,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -437,8 +509,22 @@ ShallowWrapper {
             "id": "profile_image",
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -502,8 +588,30 @@ ShallowWrapper {
             "component": [Function],
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -740,8 +848,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -787,8 +909,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -927,8 +1071,22 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Image Requirements:
+                      </p>
+                      <ul>
+                        <li>
+                          The image dimensions must be 110×110.
+                        </li>
+                        <li>
+                          The image size must be less than 256KB.
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="image.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Image"
@@ -974,8 +1132,30 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Your role at your organization.
+                      </p>
+                      <p>
+                        <b>
+                          Examples:
+                        </b>
+                      </p>
+                      <ul>
+                        <li>
+                          Professor
+                        </li>
+                        <li>
+                          Content Developer
+                        </li>
+                        <li>
+                          Director
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="position.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Position"
@@ -1112,8 +1292,22 @@ ShallowWrapper {
               "id": "profile_image",
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -1177,8 +1371,30 @@ ShallowWrapper {
               "component": [Function],
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -1545,8 +1761,22 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -1592,8 +1822,30 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -1732,8 +1984,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -1779,8 +2045,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -1917,8 +2205,22 @@ ShallowWrapper {
             "id": "profile_image",
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -1982,8 +2284,30 @@ ShallowWrapper {
             "component": [Function],
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -2220,8 +2544,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -2267,8 +2605,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -2407,8 +2767,22 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Image Requirements:
+                      </p>
+                      <ul>
+                        <li>
+                          The image dimensions must be 110×110.
+                        </li>
+                        <li>
+                          The image size must be less than 256KB.
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="image.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Image"
@@ -2454,8 +2828,30 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Your role at your organization.
+                      </p>
+                      <p>
+                        <b>
+                          Examples:
+                        </b>
+                      </p>
+                      <ul>
+                        <li>
+                          Professor
+                        </li>
+                        <li>
+                          Content Developer
+                        </li>
+                        <li>
+                          Director
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="position.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Position"
@@ -2592,8 +2988,22 @@ ShallowWrapper {
               "id": "profile_image",
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -2657,8 +3067,30 @@ ShallowWrapper {
               "component": [Function],
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -2971,8 +3403,22 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -3018,8 +3464,30 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -3158,8 +3626,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -3205,8 +3687,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -3343,8 +3847,22 @@ ShallowWrapper {
             "id": "profile_image",
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -3408,8 +3926,30 @@ ShallowWrapper {
             "component": [Function],
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -3646,8 +4186,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -3693,8 +4247,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -3833,8 +4409,22 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Image Requirements:
+                      </p>
+                      <ul>
+                        <li>
+                          The image dimensions must be 110×110.
+                        </li>
+                        <li>
+                          The image size must be less than 256KB.
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="image.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Image"
@@ -3880,8 +4470,30 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Your role at your organization.
+                      </p>
+                      <p>
+                        <b>
+                          Examples:
+                        </b>
+                      </p>
+                      <ul>
+                        <li>
+                          Professor
+                        </li>
+                        <li>
+                          Content Developer
+                        </li>
+                        <li>
+                          Director
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="position.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Position"
@@ -4018,8 +4630,22 @@ ShallowWrapper {
               "id": "profile_image",
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -4083,8 +4709,30 @@ ShallowWrapper {
               "component": [Function],
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -4397,8 +5045,22 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -4444,8 +5106,30 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -4584,8 +5268,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -4631,8 +5329,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -4769,8 +5489,22 @@ ShallowWrapper {
             "id": "profile_image",
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -4834,8 +5568,30 @@ ShallowWrapper {
             "component": [Function],
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -5072,8 +5828,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -5119,8 +5889,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -5259,8 +6051,22 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Image Requirements:
+                      </p>
+                      <ul>
+                        <li>
+                          The image dimensions must be 110×110.
+                        </li>
+                        <li>
+                          The image size must be less than 256KB.
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="image.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Image"
@@ -5306,8 +6112,30 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Your role at your organization.
+                      </p>
+                      <p>
+                        <b>
+                          Examples:
+                        </b>
+                      </p>
+                      <ul>
+                        <li>
+                          Professor
+                        </li>
+                        <li>
+                          Content Developer
+                        </li>
+                        <li>
+                          Director
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="position.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Position"
@@ -5444,8 +6272,22 @@ ShallowWrapper {
               "id": "profile_image",
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -5509,8 +6351,30 @@ ShallowWrapper {
               "component": [Function],
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -5823,8 +6687,22 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -5870,8 +6748,30 @@ ShallowWrapper {
           label={
             <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -6010,8 +6910,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -6057,8 +6971,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -6195,8 +7131,22 @@ ShallowWrapper {
             "id": "profile_image",
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Image Requirements:
+                  </p>
+                  <ul>
+                    <li>
+                      The image dimensions must be 110×110.
+                    </li>
+                    <li>
+                      The image size must be less than 256KB.
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="image.label"
               required={true}
               requiredForSubmit={false}
               text="Image"
@@ -6260,8 +7210,30 @@ ShallowWrapper {
             "component": [Function],
             "label": <FieldLabel
               className=""
-              helpText=""
-              id={null}
+              helpText={
+                <div>
+                  <p>
+                    Your role at your organization.
+                  </p>
+                  <p>
+                    <b>
+                      Examples:
+                    </b>
+                  </p>
+                  <ul>
+                    <li>
+                      Professor
+                    </li>
+                    <li>
+                      Content Developer
+                    </li>
+                    <li>
+                      Director
+                    </li>
+                  </ul>
+                </div>
+              }
+              id="position.label"
               required={true}
               requiredForSubmit={false}
               text="Position"
@@ -6498,8 +7470,22 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -6545,8 +7531,30 @@ ShallowWrapper {
             label={
               <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"
@@ -6685,8 +7693,22 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Image Requirements:
+                      </p>
+                      <ul>
+                        <li>
+                          The image dimensions must be 110×110.
+                        </li>
+                        <li>
+                          The image size must be less than 256KB.
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="image.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Image"
@@ -6732,8 +7754,30 @@ ShallowWrapper {
               label={
                 <FieldLabel
                   className=""
-                  helpText=""
-                  id={null}
+                  helpText={
+                    <div>
+                      <p>
+                        Your role at your organization.
+                      </p>
+                      <p>
+                        <b>
+                          Examples:
+                        </b>
+                      </p>
+                      <ul>
+                        <li>
+                          Professor
+                        </li>
+                        <li>
+                          Content Developer
+                        </li>
+                        <li>
+                          Director
+                        </li>
+                      </ul>
+                    </div>
+                  }
+                  id="position.label"
                   required={true}
                   requiredForSubmit={false}
                   text="Position"
@@ -6870,8 +7914,22 @@ ShallowWrapper {
               "id": "profile_image",
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Image Requirements:
+                    </p>
+                    <ul>
+                      <li>
+                        The image dimensions must be 110×110.
+                      </li>
+                      <li>
+                        The image size must be less than 256KB.
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="image.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Image"
@@ -6935,8 +7993,30 @@ ShallowWrapper {
               "component": [Function],
               "label": <FieldLabel
                 className=""
-                helpText=""
-                id={null}
+                helpText={
+                  <div>
+                    <p>
+                      Your role at your organization.
+                    </p>
+                    <p>
+                      <b>
+                        Examples:
+                      </b>
+                    </p>
+                    <ul>
+                      <li>
+                        Professor
+                      </li>
+                      <li>
+                        Content Developer
+                      </li>
+                      <li>
+                        Director
+                      </li>
+                    </ul>
+                  </div>
+                }
+                id="position.label"
                 required={true}
                 requiredForSubmit={false}
                 text="Position"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12799718/57548041-00c34d80-732e-11e9-9345-60615d062c86.png)
Oops. The "institution" is now "organization" to be more inline with the language elsewhere. The screenshot is a little dated.
![image](https://user-images.githubusercontent.com/12799718/57548052-06209800-732e-11e9-96ca-e9beac34225e.png)
