### PR TITLE
Open collapsible after custom error validation

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -40,12 +40,13 @@ export class BaseEditCourseForm extends React.Component {
     this.setCollapsible = this.setCollapsible.bind(this);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const {
       change,
       courseInfo: {
         courseSaved,
       },
+      courseSubmitInfo,
       currentFormValues,
       initialValues: {
         imageSrc: initialImageSrc,
@@ -53,6 +54,18 @@ export class BaseEditCourseForm extends React.Component {
       },
       updateFormValuesAfterSave,
     } = this.props;
+
+    // If we are transitioning off of a "submit for review" state (which means that we just
+    // finished turning fields into required so that html5 can flag them during validation) open
+    // the collapsible if and only if there are course-level errors.
+    const stoppingRunReview = prevProps.courseSubmitInfo.isSubmittingRunReview &&
+                              !courseSubmitInfo.isSubmittingRunReview;
+    const hasCourseErrors = courseSubmitInfo.errors &&
+                            courseSubmitInfo.errors !== {} &&
+                            Object.keys(courseSubmitInfo.errors) !== ['course_runs'];
+    if (stoppingRunReview && hasCourseErrors) {
+      this.openCollapsible();
+    }
 
     if (courseSaved) {
       updateFormValuesAfterSave(change, currentFormValues, initialImageSrc, initialCourseRuns);
@@ -806,6 +819,10 @@ BaseEditCourseForm.propTypes = {
   courseInfo: PropTypes.shape({
     isSubmittingEdit: PropTypes.bool,
   }),
+  courseSubmitInfo: PropTypes.shape({
+    errors: PropTypes.shape({}),
+    isSubmittingRunReview: PropTypes.bool,
+  }),
   initialValues: PropTypes.shape({
     course_runs: PropTypes.arrayOf(PropTypes.shape({})),
     imageSrc: PropTypes.string,
@@ -826,6 +843,7 @@ BaseEditCourseForm.defaultProps = {
   courseStatuses: [],
   isSubmittingForReview: false,
   courseInfo: {},
+  courseSubmitInfo: {},
   initialValues: {
     course_runs: [],
     imageSrc: '',

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -648,6 +648,7 @@ ShallowWrapper {
         "unpublished",
       ]
     }
+    courseSubmitInfo={Object {}}
     currentFormValues={
       Object {
         "additional_information": "additional info",
@@ -2210,6 +2211,7 @@ ShallowWrapper {
               "unpublished",
             ]
           }
+          courseSubmitInfo={Object {}}
           courseSubmitting={false}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={
@@ -4368,6 +4370,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -7456,6 +7459,7 @@ ShallowWrapper {
             "courseStatuses": Array [
               "unpublished",
             ],
+            "courseSubmitInfo": Object {},
             "courseSubmitting": false,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
@@ -9676,6 +9680,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -11834,6 +11839,7 @@ ShallowWrapper {
                   "unpublished",
                 ]
               }
+              courseSubmitInfo={Object {}}
               courseSubmitting={false}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={
@@ -14922,6 +14928,7 @@ ShallowWrapper {
               "courseStatuses": Array [
                 "unpublished",
               ],
+              "courseSubmitInfo": Object {},
               "courseSubmitting": false,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
@@ -16308,6 +16315,7 @@ ShallowWrapper {
         "unpublished",
       ]
     }
+    courseSubmitInfo={Object {}}
     currentFormValues={
       Object {
         "additional_information": "additional info",
@@ -17886,6 +17894,7 @@ ShallowWrapper {
               "unpublished",
             ]
           }
+          courseSubmitInfo={Object {}}
           courseSubmitting={true}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={
@@ -20057,6 +20066,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={true}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -23158,6 +23168,7 @@ ShallowWrapper {
             "courseStatuses": Array [
               "unpublished",
             ],
+            "courseSubmitInfo": Object {},
             "courseSubmitting": true,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
@@ -25392,6 +25403,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={true}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -27563,6 +27575,7 @@ ShallowWrapper {
                   "unpublished",
                 ]
               }
+              courseSubmitInfo={Object {}}
               courseSubmitting={true}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={
@@ -30664,6 +30677,7 @@ ShallowWrapper {
               "courseStatuses": Array [
                 "unpublished",
               ],
+              "courseSubmitInfo": Object {},
               "courseSubmitting": true,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
@@ -32064,6 +32078,7 @@ ShallowWrapper {
         "unpublished",
       ]
     }
+    courseSubmitInfo={Object {}}
     currentFormValues={
       Object {
         "additional_information": "additional info",
@@ -33746,6 +33761,7 @@ ShallowWrapper {
               "unpublished",
             ]
           }
+          courseSubmitInfo={Object {}}
           courseSubmitting={false}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={
@@ -36024,6 +36040,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -39340,6 +39357,7 @@ ShallowWrapper {
             "courseStatuses": Array [
               "unpublished",
             ],
+            "courseSubmitInfo": Object {},
             "courseSubmitting": false,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
@@ -41680,6 +41698,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -43958,6 +43977,7 @@ ShallowWrapper {
                   "unpublished",
                 ]
               }
+              courseSubmitInfo={Object {}}
               courseSubmitting={false}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={
@@ -47274,6 +47294,7 @@ ShallowWrapper {
               "courseStatuses": Array [
                 "unpublished",
               ],
+              "courseSubmitInfo": Object {},
               "courseSubmitting": false,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
@@ -48676,6 +48697,7 @@ ShallowWrapper {
         "unpublished",
       ]
     }
+    courseSubmitInfo={Object {}}
     currentFormValues={
       Object {
         "additional_information": "additional info",
@@ -50254,6 +50276,7 @@ ShallowWrapper {
               "unpublished",
             ]
           }
+          courseSubmitInfo={Object {}}
           courseSubmitting={false}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={
@@ -52428,6 +52451,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -55532,6 +55556,7 @@ ShallowWrapper {
             "courseStatuses": Array [
               "unpublished",
             ],
+            "courseSubmitInfo": Object {},
             "courseSubmitting": false,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
@@ -57768,6 +57793,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={
@@ -59942,6 +59968,7 @@ ShallowWrapper {
                   "unpublished",
                 ]
               }
+              courseSubmitInfo={Object {}}
               courseSubmitting={false}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={
@@ -63046,6 +63073,7 @@ ShallowWrapper {
               "courseStatuses": Array [
                 "unpublished",
               ],
+              "courseSubmitInfo": Object {},
               "courseSubmitting": false,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
@@ -64448,6 +64476,7 @@ ShallowWrapper {
         "unpublished",
       ]
     }
+    courseSubmitInfo={Object {}}
     currentFormValues={Object {}}
     entitlement={
       Object {
@@ -65962,6 +65991,7 @@ ShallowWrapper {
               "unpublished",
             ]
           }
+          courseSubmitInfo={Object {}}
           courseSubmitting={false}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={Object {}}
@@ -68072,6 +68102,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={Object {}}
@@ -71085,6 +71116,7 @@ ShallowWrapper {
             "courseStatuses": Array [
               "unpublished",
             ],
+            "courseSubmitInfo": Object {},
             "courseSubmitting": false,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {},
@@ -73259,6 +73291,7 @@ ShallowWrapper {
                 "unpublished",
               ]
             }
+            courseSubmitInfo={Object {}}
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={Object {}}
@@ -75369,6 +75402,7 @@ ShallowWrapper {
                   "unpublished",
                 ]
               }
+              courseSubmitInfo={Object {}}
               courseSubmitting={false}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={Object {}}
@@ -78382,6 +78416,7 @@ ShallowWrapper {
               "courseStatuses": Array [
                 "unpublished",
               ],
+              "courseSubmitInfo": Object {},
               "courseSubmitting": false,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {},

--- a/src/data/actions/courseSubmitInfo.js
+++ b/src/data/actions/courseSubmitInfo.js
@@ -9,8 +9,8 @@ function courseSubmittingCancel() {
   return { type: COURSE_SUBMITTING_CANCEL };
 }
 
-function courseSubmittingFailure() {
-  return { type: COURSE_SUBMITTING_FAILURE };
+function courseSubmittingFailure(errors) {
+  return { type: COURSE_SUBMITTING_FAILURE, errors };
 }
 
 function courseSubmittingInfo(targetRun = null) {

--- a/src/data/actions/courseSubmitInfo.test.js
+++ b/src/data/actions/courseSubmitInfo.test.js
@@ -39,11 +39,16 @@ describe('courseSubmittingInfo actions', () => {
   });
 
   it('handles Failure submit', () => {
+    const errors = {
+      field: 'value',
+      field2: 'value2',
+    };
     const expectedAction = {
       type: types.COURSE_SUBMITTING_FAILURE,
+      errors,
     };
 
-    expect(courseSubmittingFailure()).toEqual(expectedAction);
+    expect(courseSubmittingFailure(errors)).toEqual(expectedAction);
   });
 
   it('handles Success submit', () => {

--- a/src/data/reducers/courseSubmitInfo.js
+++ b/src/data/reducers/courseSubmitInfo.js
@@ -9,6 +9,7 @@ import {
 const initialState = {
   targetRun: null,
   isSubmittingRunReview: false,
+  errors: null,
 };
 
 function courseSubmitInfo(state = initialState, action) {
@@ -17,18 +18,22 @@ function courseSubmitInfo(state = initialState, action) {
       return Object.assign({}, state, {
         targetRun: action.targetRun,
         isSubmittingRunReview: (action.targetRun != null),
+        errors: null,
       });
     case COURSE_SUBMITTING_SUCCESS:
       return Object.assign({}, state, {
         isSubmittingRunReview: false,
+        errors: null,
       });
     case COURSE_SUBMITTING_CANCEL:
       return Object.assign({}, state, {
         isSubmittingRunReview: false,
+        errors: null,
       });
     case COURSE_SUBMITTING_FAILURE:
       return Object.assign({}, state, {
         isSubmittingRunReview: false,
+        errors: action.errors,
       });
     default:
       return state;

--- a/src/data/reducers/courseSubmitInfo.test.js
+++ b/src/data/reducers/courseSubmitInfo.test.js
@@ -1,5 +1,5 @@
 import courseSubmitInfoReducer from './courseSubmitInfo';
-import { courseSubmittingInfo } from '../actions/courseSubmitInfo';
+import { courseSubmittingInfo, courseSubmittingFailure } from '../actions/courseSubmitInfo';
 
 
 describe('courseSubmittingInfo reducer', () => {
@@ -7,6 +7,7 @@ describe('courseSubmittingInfo reducer', () => {
 
   beforeEach(() => {
     initalState = {
+      errors: null,
       targetRun: null,
       isSubmittingRunReview: false,
     };
@@ -14,6 +15,7 @@ describe('courseSubmittingInfo reducer', () => {
 
   it('initial state is valid', () => {
     expect(courseSubmitInfoReducer(undefined, {})).toEqual({
+      errors: null,
       targetRun: null,
       isSubmittingRunReview: false,
     });
@@ -26,6 +28,7 @@ describe('courseSubmittingInfo reducer', () => {
 
     expect(courseSubmitInfoReducer(initalState, courseSubmittingInfo(targetRun)))
       .toEqual({
+        errors: null,
         targetRun,
         isSubmittingRunReview: true,
       });
@@ -36,7 +39,18 @@ describe('courseSubmittingInfo reducer', () => {
 
     expect(courseSubmitInfoReducer(initalState, courseSubmittingInfo(targetRun)))
       .toEqual({
+        errors: null,
         targetRun,
+        isSubmittingRunReview: false,
+      });
+  });
+
+  it('courseSubmittingFailure sets error state', () => {
+    const prevState = { isSubmittingRunReview: true };
+    const errors = { one: 'value' };
+    expect(courseSubmitInfoReducer(prevState, courseSubmittingFailure(errors)))
+      .toEqual({
+        errors,
         isSubmittingRunReview: false,
       });
   });


### PR DESCRIPTION
Our custom error validation was getting in the way of some fields being able to open the collapsible to focus the field in error.

This fixes that by stopping validation in an error case and having the edit course form notice.

Stopping validation also prevents the submit button from spinning forever.

https://openedx.atlassian.net/browse/DISCO-972
https://openedx.atlassian.net/browse/DISCO-973

I also opened https://openedx.atlassian.net/browse/DISCO-992 to deal with the setTimeout call that I'm lazily introducing.