### PR TITLE
Start Date bug

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -155,7 +155,8 @@ class CollapsibleCourseRun extends React.Component {
           }
           extraInput={{
             onInvalid: this.openCollapsible,
-            min: getDateString((moment(courseRun.go_live_date) || moment())),
+            min: moment(courseRun.go_live_date).isBefore(moment()) ?
+              getDateString(courseRun.go_live_date) : getDateString(moment()),
           }}
           placeholder="mm/dd/yyyy"
           disabled={courseInReview}
@@ -168,7 +169,8 @@ class CollapsibleCourseRun extends React.Component {
           helpText={startDateHelp}
           disabled={courseInReview}
           required
-          minDate={getDateString(moment(courseRun.start))}
+          minDate={moment(courseRun.start).isBefore(moment()) ?
+            getDateString(courseRun.start) : getDateString(moment())}
           onInvalid={this.openCollapsible}
         />
         <Field


### PR DESCRIPTION
Users can change their course run start dates to
today or later, unless their start date has already
passed. In the latter case, they can change the start
date to the initially set start date or later (this may
result in changing a start date to a date in the past,
which is a small use case).

DISCO-1135