### PR TITLE
Support viewing courses we can't edit

### DIFF
--- a/src/components/EditCoursePage/CollapsibleCourseRun.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.jsx
@@ -109,6 +109,7 @@ class CollapsibleCourseRun extends React.Component {
       courseInReview,
       courseRun,
       courseSubmitting,
+      editable,
       isSubmittingForReview,
       languageOptions,
       programOptions,
@@ -128,6 +129,8 @@ class CollapsibleCourseRun extends React.Component {
     // Checks if the current course run is the one triggering submission for review
     const courseRunSubmitting = !courseRunInReview && isSubmittingForReview && targetRun &&
       (targetRun.key === courseRun.key);
+
+    const disabled = courseInReview || !editable;
 
     return (
       <Collapsible
@@ -169,7 +172,7 @@ class CollapsibleCourseRun extends React.Component {
               getDateString(courseRun.go_live_date) : getDateString(moment()),
           }}
           placeholder="mm/dd/yyyy"
-          disabled={courseInReview}
+          disabled={disabled}
           required={courseRunSubmitting}
         />
         <Field
@@ -178,7 +181,7 @@ class CollapsibleCourseRun extends React.Component {
           dateLabel="Start date"
           timeLabel="Start time"
           helpText={startDateHelp}
-          disabled={courseInReview}
+          disabled={disabled}
           required
           minDate={moment(courseRun.start).isBefore(moment()) ?
             getDateString(courseRun.start) : getDateString(moment())}
@@ -190,7 +193,7 @@ class CollapsibleCourseRun extends React.Component {
           dateLabel="End date"
           timeLabel="End time"
           helpText={endDateHelp}
-          disabled={courseInReview}
+          disabled={disabled}
           required
           minDate={getDateString(moment(courseRun.start).add(1, 'd') || moment())}
           onInvalid={this.openCollapsible}
@@ -209,7 +212,7 @@ class CollapsibleCourseRun extends React.Component {
             />
           }
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
           required={courseRunSubmitting}
         />
         <FieldLabel
@@ -230,7 +233,7 @@ class CollapsibleCourseRun extends React.Component {
           name={`${courseId}.staff`}
           component={StaffList}
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
           courseRunKey={courseRun.key}
           owners={owners}
           courseUuid={courseUuid}
@@ -262,7 +265,7 @@ class CollapsibleCourseRun extends React.Component {
                 min: 0,
                 max: 168,
               }}
-              disabled={courseInReview}
+              disabled={disabled}
               required={courseRunSubmitting}
             />
           </div>
@@ -290,7 +293,7 @@ class CollapsibleCourseRun extends React.Component {
                 min: 1,
                 max: 168,
               }}
-              disabled={courseInReview}
+              disabled={disabled}
               required={courseRunSubmitting}
             />
           </div>
@@ -311,7 +314,7 @@ class CollapsibleCourseRun extends React.Component {
             />
           }
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
           required={courseRunSubmitting}
         />
         <Field
@@ -321,7 +324,7 @@ class CollapsibleCourseRun extends React.Component {
           options={languageOptions}
           label={<FieldLabel text="Content language" />}
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
           required={courseRunSubmitting}
         />
         <FieldLabel text="Transcript languages" className="mb-2" />
@@ -330,7 +333,7 @@ class CollapsibleCourseRun extends React.Component {
           component={TranscriptLanguage}
           languageOptions={languageOptions}
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
         />
         <Field
           name={`${courseId}.expected_program_type`}
@@ -353,7 +356,7 @@ class CollapsibleCourseRun extends React.Component {
             />
           }
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
         />
         <Field
           name={`${courseId}.expected_program_name`}
@@ -375,7 +378,7 @@ class CollapsibleCourseRun extends React.Component {
             />
           }
           extraInput={{ onInvalid: this.openCollapsible }}
-          disabled={courseInReview}
+          disabled={disabled}
         />
         <div>
           <FieldLabel
@@ -393,24 +396,26 @@ class CollapsibleCourseRun extends React.Component {
           />
           <div className="mb-3">{courseRun.has_ofac_restrictions ? 'Yes' : 'No'}</div>
         </div>
-        <ButtonToolbar>
-          <ActionButton
-            // only disable if *this run* is in review
-            disabled={courseSubmitting || courseRunInReview}
-            // Pass the submitting course run up to validate different fields based on status
-            onClick={() => store.dispatch(courseSubmittingInfo(courseRun))}
-            labels={{
-              default: courseRun.status === PUBLISHED ? 'Publish Run' : 'Submit Run for Review',
-              pending: courseRun.status === PUBLISHED ? 'Publishing Run' : 'Submitting Run for Review',
-            }}
-            state={
-              (
-                courseSubmitting ||
-                (courseSubmitInfo && courseSubmitInfo.isSubmittingRunReview)
-              ) ? 'pending' : 'default'
-            }
-          />
-        </ButtonToolbar>
+        {editable &&
+          <ButtonToolbar>
+            <ActionButton
+              // only disable if *this run* is in review
+              disabled={courseSubmitting || courseRunInReview}
+              // Pass the submitting course run up to validate different fields based on status
+              onClick={() => store.dispatch(courseSubmittingInfo(courseRun))}
+              labels={{
+                default: courseRun.status === PUBLISHED ? 'Publish Run' : 'Submit Run for Review',
+                pending: courseRun.status === PUBLISHED ? 'Publishing Run' : 'Submitting Run for Review',
+              }}
+              state={
+                (
+                  courseSubmitting ||
+                  (courseSubmitInfo && courseSubmitInfo.isSubmittingRunReview)
+                ) ? 'pending' : 'default'
+              }
+            />
+          </ButtonToolbar>
+        }
       </Collapsible>
     );
   }
@@ -425,6 +430,7 @@ CollapsibleCourseRun.propTypes = {
     isSubmittingRunReview: PropTypes.bool,
   }),
   courseUuid: PropTypes.string.isRequired,
+  editable: PropTypes.bool,
   isSubmittingForReview: PropTypes.bool,
   languageOptions: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
@@ -450,6 +456,7 @@ CollapsibleCourseRun.defaultProps = {
   courseSubmitInfo: {
     isSubmittingRunReview: false,
   },
+  editable: false,
   isSubmittingForReview: false,
   owners: [],
   sourceInfo: {},

--- a/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
+++ b/src/components/EditCoursePage/CollapsibleCourseRun.test.jsx
@@ -119,6 +119,7 @@ describe('Collapsible Course Run', () => {
       courseRun={unpublishedCourseRun}
       courseId="test-course"
       courseUuid="11111111-1111-1111-1111-111111111111"
+      editable
     />);
 
     const mockDispatch = jest.spyOn(store, 'dispatch');

--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -99,15 +99,15 @@ export class BaseEditCourseForm extends React.Component {
       return [];
     }
 
-    return data.actions.PUT;
+    return data.actions.POST;
   }
 
-  getAddCourseRunButton(courseInReview, pristine, uuid) {
+  getAddCourseRunButton(disabled, pristine, uuid) {
     /** Disabling a Link is discouraged and disabling a button within a link results
      * in a Disabled button with a link that will still underline on hover.
      * This method will remove the Link when disabling the button.
      */
-    if (courseInReview) {
+    if (disabled) {
       return '';
     }
 
@@ -184,6 +184,7 @@ export class BaseEditCourseForm extends React.Component {
       courseStatuses,
       id,
       isSubmittingForReview,
+      editable,
       courseInfo,
     } = this.props;
     const {
@@ -213,6 +214,8 @@ export class BaseEditCourseForm extends React.Component {
     subjectOptions.unshift({ label: '--', value: '' });
     programOptions.unshift({ label: '--', value: '' });
 
+    const disabled = courseInReview || !editable;
+
     return (
       <div className="edit-course-form">
         <form id={id} onSubmit={handleSubmit}>
@@ -239,7 +242,7 @@ export class BaseEditCourseForm extends React.Component {
               }
               extraInput={{ onInvalid: this.openCollapsible }}
               required
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <div>
               <FieldLabel id="number" text="Number" className="mb-2" />
@@ -258,7 +261,7 @@ export class BaseEditCourseForm extends React.Component {
               }
               extraInput={{ onInvalid: this.openCollapsible }}
               options={this.getEnrollmentTrackOptions()}
-              disabled={courseInReview || !!entitlement.sku}
+              disabled={disabled || !!entitlement.sku}
             />
             {ENTITLEMENT_TRACKS.includes(currentFormValues.mode) && <Field
               name="price"
@@ -271,7 +274,7 @@ export class BaseEditCourseForm extends React.Component {
                 step: 0.01,
                 max: 10000.00,
               }}
-              disabled={courseInReview}
+              disabled={disabled}
               required={isSubmittingForReview}
             />}
             <Field
@@ -317,7 +320,7 @@ export class BaseEditCourseForm extends React.Component {
               requiredHeight={675}
               id="image"
               className="course-image"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <hr />
             <Field
@@ -358,7 +361,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={500}
               id="sdesc"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="full_description"
@@ -397,7 +400,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={2500}
               id="ldesc"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="outcome"
@@ -433,7 +436,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={2500}
               id="outcome"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="syllabus_raw"
@@ -490,7 +493,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={500}
               id="syllabus"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="prerequisites_raw"
@@ -528,7 +531,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={1000}
               id="prereq"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="learner_testimonials"
@@ -567,7 +570,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={500}
               id="learner-testimonials"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             <Field
               name="faq"
@@ -605,7 +608,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={2500}
               id="faq"
-              disabled={courseInReview}
+              disabled={disabled}
             />
             {administrator && <Field
               name="additional_information"
@@ -625,7 +628,7 @@ export class BaseEditCourseForm extends React.Component {
               extraInput={{ onInvalid: this.openCollapsible }}
               maxChars={2500}
               id="additional-information"
-              disabled={courseInReview}
+              disabled={disabled}
             />}
             {administrator && <Field
               name="videoSrc"
@@ -683,7 +686,7 @@ export class BaseEditCourseForm extends React.Component {
                 />
               }
               extraInput={{ onInvalid: this.openCollapsible }}
-              disabled={courseInReview}
+              disabled={disabled}
             />}
             <hr />
             <Field
@@ -720,7 +723,7 @@ export class BaseEditCourseForm extends React.Component {
               }
               extraInput={{ onInvalid: this.openCollapsible }}
               options={levelTypeOptions}
-              disabled={courseInReview}
+              disabled={disabled}
               required={isSubmittingForReview}
             />
             <Field
@@ -752,7 +755,7 @@ export class BaseEditCourseForm extends React.Component {
               }
               extraInput={{ onInvalid: this.openCollapsible }}
               options={subjectOptions}
-              disabled={courseInReview}
+              disabled={disabled}
               required={isSubmittingForReview}
             />
             <Field
@@ -761,7 +764,7 @@ export class BaseEditCourseForm extends React.Component {
               label={<FieldLabel text="Secondary subject" optional />}
               extraInput={{ onInvalid: this.openCollapsible }}
               options={subjectOptions}
-              disabled={courseInReview}
+              disabled={disabled}
               optional
             />
             <Field
@@ -770,7 +773,7 @@ export class BaseEditCourseForm extends React.Component {
               label={<FieldLabel text="Tertiary subject" optional />}
               extraInput={{ onInvalid: this.openCollapsible }}
               options={subjectOptions}
-              disabled={courseInReview}
+              disabled={disabled}
               optional
             />
           </Collapsible>
@@ -786,25 +789,27 @@ export class BaseEditCourseForm extends React.Component {
             courseSubmitting={submitting}
             {...this.props}
           />
-          {this.getAddCourseRunButton(courseInReview, pristine, uuid)}
-          <ButtonToolbar className="mt-3">
-            <ActionButton
-              disabled={courseInReview || submitting}
-              labels={{
-                default: 'Save & Continue Editing',
-                pending: 'Saving Course',
-                complete: 'Course Saved',
-              }}
-              state={submitState}
-              onClick={() => {
-               /* Bit of a hack used to clear old validation errors that might be around from
-                *  trying to submit for review with errors.
-                */
-               store.dispatch(stopSubmit(id));
-               store.dispatch(courseSubmittingInfo());
-              }}
-            />
-          </ButtonToolbar>
+          {this.getAddCourseRunButton(disabled, pristine, uuid)}
+          {editable &&
+            <ButtonToolbar className="mt-3">
+              <ActionButton
+                disabled={disabled || submitting}
+                labels={{
+                  default: 'Save & Continue Editing',
+                  pending: 'Saving Course',
+                  complete: 'Course Saved',
+                }}
+                state={submitState}
+                onClick={() => {
+                  /* Bit of a hack used to clear old validation errors that might be around from
+                   *  trying to submit for review with errors.
+                   */
+                  store.dispatch(stopSubmit(id));
+                  store.dispatch(courseSubmittingInfo());
+                }}
+              />
+            </ButtonToolbar>
+          }
         </form>
       </div>
     );
@@ -839,6 +844,7 @@ BaseEditCourseForm.propTypes = {
   courseStatuses: PropTypes.arrayOf(PropTypes.string),
   id: PropTypes.string.isRequired,
   isSubmittingForReview: PropTypes.bool,
+  editable: PropTypes.bool,
   courseInfo: PropTypes.shape({
     isSubmittingEdit: PropTypes.bool,
   }),
@@ -865,6 +871,7 @@ BaseEditCourseForm.defaultProps = {
   courseInReview: false,
   courseStatuses: [],
   isSubmittingForReview: false,
+  editable: false,
   courseInfo: {},
   courseSubmitInfo: {},
   initialValues: {

--- a/src/components/EditCoursePage/EditCourseForm.test.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.test.jsx
@@ -10,7 +10,7 @@ describe('BaseEditCourseForm', () => {
   const courseOptions = {
     data: {
       actions: {
-        PUT: {
+        POST: {
           level_type: {
             choices: [
               { display_name: 'Beginner', value: 'beginner' },
@@ -513,6 +513,7 @@ describe('BaseEditCourseForm', () => {
     mode: 'verified',
     price: '77',
     uuid: '11111111-1111-1111-1111-111111111111',
+    editable: true,
   };
   const entitlement = {
     mode: 'verified',

--- a/src/components/EditCoursePage/EditCoursePage.test.jsx
+++ b/src/components/EditCoursePage/EditCoursePage.test.jsx
@@ -77,7 +77,7 @@ describe('EditCoursePage', () => {
   const courseOptions = {
     data: {
       actions: {
-        PUT: {
+        POST: {
           level_type: {
             choices: [
               { display_name: 'Beginner', value: 'beginner' },
@@ -350,6 +350,7 @@ describe('EditCoursePage', () => {
       syllabus_raw: null,
       title: 'demo4004',
       videoSrc: null,
+      editable: true,
     };
 
     const expectedSendCourse = {
@@ -504,6 +505,7 @@ describe('EditCoursePage', () => {
 
     it('upon course submission, StatusAlert is set to appear', () => {
       const component = shallow(<EditCoursePage
+        courseInfo={{ data: { editable: true } }}
         courseSubmitInfo={{ showReviewStatusAlert: true }}
       />);
       const reviewAlert = component.find(StatusAlert);
@@ -513,7 +515,7 @@ describe('EditCoursePage', () => {
 
     it('upon course run creation, StatusAlert is set to appear', () => {
       const component = shallow(<EditCoursePage
-        courseInfo={{ data: { title: 'TestCourse101' }, showCreateStatusAlert: true }}
+        courseInfo={{ data: { title: 'TestCourse101', editable: true }, showCreateStatusAlert: true }}
       />);
       const createAlert = component.find(StatusAlert);
       const createMessage = 'Course run has been created in studio. See link below.';

--- a/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/CollapsibleCourseRun.test.jsx.snap
@@ -31,6 +31,7 @@ ShallowWrapper {
     }
     courseSubmitting={false}
     courseUuid="11111111-1111-1111-1111-111111111111"
+    editable={false}
     isSubmittingForReview={false}
     languageOptions={
       Array [
@@ -80,7 +81,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "min": "1999-12-31",
@@ -119,7 +120,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="Start date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -145,7 +146,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="End date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -162,7 +163,7 @@ ShallowWrapper {
         <hr />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -220,7 +221,7 @@ ShallowWrapper {
           component={[Function]}
           courseRunKey="edX101+DemoX"
           courseUuid="11111111-1111-1111-1111-111111111111"
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -239,7 +240,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -273,7 +274,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -305,7 +306,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -333,7 +334,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -371,7 +372,7 @@ ShallowWrapper {
         />,
         <FieldArray
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -389,7 +390,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -416,7 +417,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -462,24 +463,7 @@ ShallowWrapper {
             No
           </div>
         </div>,
-        <ButtonToolbar
-          className=""
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />
-        </ButtonToolbar>,
+        false,
       ],
       "expandedTitle": undefined,
       "iconId": "collapsible-icon-test-course",
@@ -558,7 +542,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "min": "1999-12-31",
             "onInvalid": [Function],
@@ -601,7 +585,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "Start date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               Start on a Tuesday, Wednesday, or Thursday.
@@ -633,7 +617,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "End date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -664,7 +648,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -730,7 +714,7 @@ ShallowWrapper {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
           "courseUuid": "11111111-1111-1111-1111-111111111111",
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -754,7 +738,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -788,7 +772,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -829,7 +813,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -866,7 +850,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 0,
@@ -903,7 +887,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -940,7 +924,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 1,
@@ -979,7 +963,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -1011,7 +995,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -1059,7 +1043,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -1081,7 +1065,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -1113,7 +1097,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -1202,49 +1186,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />,
-          "className": "",
-          "leftJustify": false,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "",
-            "disabled": false,
-            "labels": Object {
-              "default": "Publish Run",
-              "pending": "Publishing Run",
-            },
-            "onClick": [Function],
-            "primary": true,
-            "state": "default",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": [Function],
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -1267,7 +1209,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "min": "1999-12-31",
@@ -1306,7 +1248,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="Start date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -1332,7 +1274,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="End date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -1349,7 +1291,7 @@ ShallowWrapper {
           <hr />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1407,7 +1349,7 @@ ShallowWrapper {
             component={[Function]}
             courseRunKey="edX101+DemoX"
             courseUuid="11111111-1111-1111-1111-111111111111"
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1426,7 +1368,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -1460,7 +1402,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -1492,7 +1434,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1520,7 +1462,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1558,7 +1500,7 @@ ShallowWrapper {
           />,
           <FieldArray
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1576,7 +1518,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1603,7 +1545,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1649,24 +1591,7 @@ ShallowWrapper {
               No
             </div>
           </div>,
-          <ButtonToolbar
-            className=""
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Publish Run",
-                  "pending": "Publishing Run",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />
-          </ButtonToolbar>,
+          false,
         ],
         "expandedTitle": undefined,
         "iconId": "collapsible-icon-test-course",
@@ -1745,7 +1670,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "min": "1999-12-31",
               "onInvalid": [Function],
@@ -1788,7 +1713,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "Start date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 Start on a Tuesday, Wednesday, or Thursday.
@@ -1820,7 +1745,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "End date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -1851,7 +1776,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -1917,7 +1842,7 @@ ShallowWrapper {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
             "courseUuid": "11111111-1111-1111-1111-111111111111",
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -1941,7 +1866,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -1975,7 +1900,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -2016,7 +1941,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -2053,7 +1978,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 0,
@@ -2090,7 +2015,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -2127,7 +2052,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 1,
@@ -2166,7 +2091,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -2198,7 +2123,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -2246,7 +2171,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -2268,7 +2193,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -2300,7 +2225,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -2389,49 +2314,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Publish Run",
-                  "pending": "Publishing Run",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />,
-            "className": "",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "default",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        false,
       ],
       "type": [Function],
     },
@@ -2494,6 +2377,7 @@ ShallowWrapper {
     }
     courseSubmitting={false}
     courseUuid="11111111-1111-1111-1111-111111111111"
+    editable={false}
     isSubmittingForReview={false}
     languageOptions={
       Array [
@@ -2543,7 +2427,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "min": "1999-12-31",
@@ -2582,7 +2466,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="Start date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -2608,7 +2492,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="End date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -2625,7 +2509,7 @@ ShallowWrapper {
         <hr />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2683,7 +2567,7 @@ ShallowWrapper {
           component={[Function]}
           courseRunKey="edX101+DemoX"
           courseUuid="11111111-1111-1111-1111-111111111111"
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2702,7 +2586,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -2736,7 +2620,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -2768,7 +2652,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2796,7 +2680,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2834,7 +2718,7 @@ ShallowWrapper {
         />,
         <FieldArray
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2852,7 +2736,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2879,7 +2763,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -2925,24 +2809,7 @@ ShallowWrapper {
             No
           </div>
         </div>,
-        <ButtonToolbar
-          className=""
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />
-        </ButtonToolbar>,
+        false,
       ],
       "expandedTitle": undefined,
       "iconId": "collapsible-icon-test-course",
@@ -3021,7 +2888,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "min": "1999-12-31",
             "onInvalid": [Function],
@@ -3064,7 +2931,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "Start date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               Start on a Tuesday, Wednesday, or Thursday.
@@ -3096,7 +2963,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "End date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -3127,7 +2994,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3193,7 +3060,7 @@ ShallowWrapper {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
           "courseUuid": "11111111-1111-1111-1111-111111111111",
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3217,7 +3084,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3251,7 +3118,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3292,7 +3159,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3329,7 +3196,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 0,
@@ -3366,7 +3233,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3403,7 +3270,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 1,
@@ -3442,7 +3309,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3474,7 +3341,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3522,7 +3389,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3544,7 +3411,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3576,7 +3443,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -3665,49 +3532,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />,
-          "className": "",
-          "leftJustify": false,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "",
-            "disabled": false,
-            "labels": Object {
-              "default": "Submit Run for Review",
-              "pending": "Submitting Run for Review",
-            },
-            "onClick": [Function],
-            "primary": true,
-            "state": "default",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": [Function],
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -3730,7 +3555,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "min": "1999-12-31",
@@ -3769,7 +3594,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="Start date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -3795,7 +3620,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="End date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -3812,7 +3637,7 @@ ShallowWrapper {
           <hr />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -3870,7 +3695,7 @@ ShallowWrapper {
             component={[Function]}
             courseRunKey="edX101+DemoX"
             courseUuid="11111111-1111-1111-1111-111111111111"
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -3889,7 +3714,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3923,7 +3748,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -3955,7 +3780,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -3983,7 +3808,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -4021,7 +3846,7 @@ ShallowWrapper {
           />,
           <FieldArray
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -4039,7 +3864,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -4066,7 +3891,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -4112,24 +3937,7 @@ ShallowWrapper {
               No
             </div>
           </div>,
-          <ButtonToolbar
-            className=""
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />
-          </ButtonToolbar>,
+          false,
         ],
         "expandedTitle": undefined,
         "iconId": "collapsible-icon-test-course",
@@ -4208,7 +4016,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "min": "1999-12-31",
               "onInvalid": [Function],
@@ -4251,7 +4059,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "Start date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 Start on a Tuesday, Wednesday, or Thursday.
@@ -4283,7 +4091,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "End date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -4314,7 +4122,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4380,7 +4188,7 @@ ShallowWrapper {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
             "courseUuid": "11111111-1111-1111-1111-111111111111",
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4404,7 +4212,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -4438,7 +4246,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -4479,7 +4287,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -4516,7 +4324,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 0,
@@ -4553,7 +4361,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -4590,7 +4398,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 1,
@@ -4629,7 +4437,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4661,7 +4469,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4709,7 +4517,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4731,7 +4539,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4763,7 +4571,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -4852,49 +4660,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />,
-            "className": "",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "default",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        false,
       ],
       "type": [Function],
     },
@@ -4957,6 +4723,7 @@ ShallowWrapper {
     }
     courseSubmitting={false}
     courseUuid="11111111-1111-1111-1111-111111111111"
+    editable={false}
     isSubmittingForReview={true}
     languageOptions={
       Array [
@@ -5006,7 +4773,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "min": "1999-12-31",
@@ -5045,7 +4812,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="Start date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -5071,7 +4838,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="End date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -5088,7 +4855,7 @@ ShallowWrapper {
         <hr />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5146,7 +4913,7 @@ ShallowWrapper {
           component={[Function]}
           courseRunKey="edX101+DemoX"
           courseUuid="11111111-1111-1111-1111-111111111111"
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5165,7 +4932,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -5199,7 +4966,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -5231,7 +4998,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5259,7 +5026,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5297,7 +5064,7 @@ ShallowWrapper {
         />,
         <FieldArray
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5315,7 +5082,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5342,7 +5109,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -5388,24 +5155,7 @@ ShallowWrapper {
             No
           </div>
         </div>,
-        <ButtonToolbar
-          className=""
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />
-        </ButtonToolbar>,
+        false,
       ],
       "expandedTitle": undefined,
       "iconId": "collapsible-icon-test-course",
@@ -5484,7 +5234,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "min": "1999-12-31",
             "onInvalid": [Function],
@@ -5527,7 +5277,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "Start date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               Start on a Tuesday, Wednesday, or Thursday.
@@ -5559,7 +5309,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "End date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -5590,7 +5340,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -5656,7 +5406,7 @@ ShallowWrapper {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
           "courseUuid": "11111111-1111-1111-1111-111111111111",
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -5680,7 +5430,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -5714,7 +5464,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -5755,7 +5505,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -5792,7 +5542,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 0,
@@ -5829,7 +5579,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -5866,7 +5616,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 1,
@@ -5905,7 +5655,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -5937,7 +5687,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -5985,7 +5735,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -6007,7 +5757,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -6039,7 +5789,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -6128,49 +5878,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />,
-          "className": "",
-          "leftJustify": false,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "",
-            "disabled": false,
-            "labels": Object {
-              "default": "Submit Run for Review",
-              "pending": "Submitting Run for Review",
-            },
-            "onClick": [Function],
-            "primary": true,
-            "state": "default",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": [Function],
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -6193,7 +5901,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "min": "1999-12-31",
@@ -6232,7 +5940,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="Start date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -6258,7 +5966,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="End date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -6275,7 +5983,7 @@ ShallowWrapper {
           <hr />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6333,7 +6041,7 @@ ShallowWrapper {
             component={[Function]}
             courseRunKey="edX101+DemoX"
             courseUuid="11111111-1111-1111-1111-111111111111"
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6352,7 +6060,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -6386,7 +6094,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -6418,7 +6126,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6446,7 +6154,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6484,7 +6192,7 @@ ShallowWrapper {
           />,
           <FieldArray
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6502,7 +6210,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6529,7 +6237,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -6575,24 +6283,7 @@ ShallowWrapper {
               No
             </div>
           </div>,
-          <ButtonToolbar
-            className=""
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />
-          </ButtonToolbar>,
+          false,
         ],
         "expandedTitle": undefined,
         "iconId": "collapsible-icon-test-course",
@@ -6671,7 +6362,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "min": "1999-12-31",
               "onInvalid": [Function],
@@ -6714,7 +6405,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "Start date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 Start on a Tuesday, Wednesday, or Thursday.
@@ -6746,7 +6437,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "End date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -6777,7 +6468,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -6843,7 +6534,7 @@ ShallowWrapper {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
             "courseUuid": "11111111-1111-1111-1111-111111111111",
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -6867,7 +6558,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -6901,7 +6592,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -6942,7 +6633,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -6979,7 +6670,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 0,
@@ -7016,7 +6707,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -7053,7 +6744,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 1,
@@ -7092,7 +6783,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -7124,7 +6815,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -7172,7 +6863,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -7194,7 +6885,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -7226,7 +6917,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -7315,49 +7006,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />,
-            "className": "",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "default",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        false,
       ],
       "type": [Function],
     },
@@ -7420,6 +7069,7 @@ ShallowWrapper {
     }
     courseSubmitting={false}
     courseUuid="11111111-1111-1111-1111-111111111111"
+    editable={false}
     isSubmittingForReview={true}
     languageOptions={
       Array [
@@ -7469,7 +7119,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "min": "1999-12-31",
@@ -7508,7 +7158,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="Start date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -7534,7 +7184,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="End date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -7551,7 +7201,7 @@ ShallowWrapper {
         <hr />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7609,7 +7259,7 @@ ShallowWrapper {
           component={[Function]}
           courseRunKey="edX101+DemoX"
           courseUuid="11111111-1111-1111-1111-111111111111"
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7628,7 +7278,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -7662,7 +7312,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -7694,7 +7344,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7722,7 +7372,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7760,7 +7410,7 @@ ShallowWrapper {
         />,
         <FieldArray
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7778,7 +7428,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7805,7 +7455,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -7851,24 +7501,7 @@ ShallowWrapper {
             No
           </div>
         </div>,
-        <ButtonToolbar
-          className=""
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />
-        </ButtonToolbar>,
+        false,
       ],
       "expandedTitle": undefined,
       "iconId": "collapsible-icon-test-course",
@@ -7947,7 +7580,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "min": "1999-12-31",
             "onInvalid": [Function],
@@ -7990,7 +7623,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "Start date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               Start on a Tuesday, Wednesday, or Thursday.
@@ -8022,7 +7655,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "End date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -8053,7 +7686,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8119,7 +7752,7 @@ ShallowWrapper {
           "component": [Function],
           "courseRunKey": "edX101+DemoX",
           "courseUuid": "11111111-1111-1111-1111-111111111111",
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8143,7 +7776,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8177,7 +7810,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8218,7 +7851,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8255,7 +7888,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 0,
@@ -8292,7 +7925,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8329,7 +7962,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 1,
@@ -8368,7 +8001,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8400,7 +8033,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8448,7 +8081,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8470,7 +8103,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8502,7 +8135,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -8591,49 +8224,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />,
-          "className": "",
-          "leftJustify": false,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "",
-            "disabled": false,
-            "labels": Object {
-              "default": "Publish Run",
-              "pending": "Publishing Run",
-            },
-            "onClick": [Function],
-            "primary": true,
-            "state": "default",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": [Function],
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -8656,7 +8247,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "min": "1999-12-31",
@@ -8695,7 +8286,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="Start date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -8721,7 +8312,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="End date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -8738,7 +8329,7 @@ ShallowWrapper {
           <hr />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8796,7 +8387,7 @@ ShallowWrapper {
             component={[Function]}
             courseRunKey="edX101+DemoX"
             courseUuid="11111111-1111-1111-1111-111111111111"
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8815,7 +8406,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8849,7 +8440,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -8881,7 +8472,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8909,7 +8500,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8947,7 +8538,7 @@ ShallowWrapper {
           />,
           <FieldArray
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8965,7 +8556,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -8992,7 +8583,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -9038,24 +8629,7 @@ ShallowWrapper {
               No
             </div>
           </div>,
-          <ButtonToolbar
-            className=""
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Publish Run",
-                  "pending": "Publishing Run",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />
-          </ButtonToolbar>,
+          false,
         ],
         "expandedTitle": undefined,
         "iconId": "collapsible-icon-test-course",
@@ -9134,7 +8708,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "min": "1999-12-31",
               "onInvalid": [Function],
@@ -9177,7 +8751,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "Start date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 Start on a Tuesday, Wednesday, or Thursday.
@@ -9209,7 +8783,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "End date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -9240,7 +8814,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9306,7 +8880,7 @@ ShallowWrapper {
             "component": [Function],
             "courseRunKey": "edX101+DemoX",
             "courseUuid": "11111111-1111-1111-1111-111111111111",
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9330,7 +8904,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -9364,7 +8938,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -9405,7 +8979,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -9442,7 +9016,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 0,
@@ -9479,7 +9053,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -9516,7 +9090,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 1,
@@ -9555,7 +9129,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9587,7 +9161,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9635,7 +9209,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9657,7 +9231,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9689,7 +9263,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -9778,49 +9352,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Publish Run",
-                  "pending": "Publishing Run",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />,
-            "className": "",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "default": "Publish Run",
-                "pending": "Publishing Run",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "default",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        false,
       ],
       "type": [Function],
     },
@@ -9866,6 +9398,7 @@ ShallowWrapper {
     }
     courseSubmitting={false}
     courseUuid="11111111-1111-1111-1111-111111111111"
+    editable={false}
     isSubmittingForReview={false}
     languageOptions={Array []}
     owners={Array []}
@@ -9901,7 +9434,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "min": "2001-01-01",
@@ -9940,7 +9473,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="Start date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -9966,7 +9499,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           dateLabel="End date"
-          disabled={false}
+          disabled={true}
           helpText={
             <div>
               <p>
@@ -9983,7 +9516,7 @@ ShallowWrapper {
         <hr />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10033,7 +9566,7 @@ ShallowWrapper {
         <Field
           component={[Function]}
           courseUuid="11111111-1111-1111-1111-111111111111"
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10052,7 +9585,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -10086,7 +9619,7 @@ ShallowWrapper {
           >
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 168,
@@ -10118,7 +9651,7 @@ ShallowWrapper {
         </div>,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10146,7 +9679,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10177,7 +9710,7 @@ ShallowWrapper {
         />,
         <FieldArray
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10188,7 +9721,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10215,7 +9748,7 @@ ShallowWrapper {
         />,
         <Field
           component={[Function]}
-          disabled={false}
+          disabled={true}
           extraInput={
             Object {
               "onInvalid": [Function],
@@ -10261,24 +9794,7 @@ ShallowWrapper {
             No
           </div>
         </div>,
-        <ButtonToolbar
-          className=""
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />
-        </ButtonToolbar>,
+        false,
       ],
       "expandedTitle": undefined,
       "iconId": "collapsible-icon-test-course",
@@ -10355,7 +9871,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "min": "2001-01-01",
             "onInvalid": [Function],
@@ -10398,7 +9914,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "Start date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               Start on a Tuesday, Wednesday, or Thursday.
@@ -10430,7 +9946,7 @@ ShallowWrapper {
         "props": Object {
           "component": [Function],
           "dateLabel": "End date",
-          "disabled": false,
+          "disabled": true,
           "helpText": <div>
             <p>
               If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -10461,7 +9977,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10522,7 +10038,7 @@ ShallowWrapper {
           "component": [Function],
           "courseRunKey": undefined,
           "courseUuid": "11111111-1111-1111-1111-111111111111",
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10546,7 +10062,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -10580,7 +10096,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -10621,7 +10137,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -10658,7 +10174,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 0,
@@ -10695,7 +10211,7 @@ ShallowWrapper {
             "props": Object {
               "children": <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -10732,7 +10248,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 168,
                   "min": 1,
@@ -10771,7 +10287,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10803,7 +10319,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10846,7 +10362,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10863,7 +10379,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10895,7 +10411,7 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "component": [Function],
-          "disabled": false,
+          "disabled": true,
           "extraInput": Object {
             "onInvalid": [Function],
           },
@@ -10984,49 +10500,7 @@ ShallowWrapper {
         ],
         "type": "div",
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "children": <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="default"
-          />,
-          "className": "",
-          "leftJustify": false,
-        },
-        "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "",
-            "disabled": false,
-            "labels": Object {
-              "default": "Submit Run for Review",
-              "pending": "Submitting Run for Review",
-            },
-            "onClick": [Function],
-            "primary": true,
-            "state": "default",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        "type": [Function],
-      },
+      false,
     ],
     "type": [Function],
   },
@@ -11049,7 +10523,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "min": "2001-01-01",
@@ -11088,7 +10562,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="Start date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -11114,7 +10588,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             dateLabel="End date"
-            disabled={false}
+            disabled={true}
             helpText={
               <div>
                 <p>
@@ -11131,7 +10605,7 @@ ShallowWrapper {
           <hr />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11181,7 +10655,7 @@ ShallowWrapper {
           <Field
             component={[Function]}
             courseUuid="11111111-1111-1111-1111-111111111111"
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11200,7 +10674,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -11234,7 +10708,7 @@ ShallowWrapper {
             >
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 168,
@@ -11266,7 +10740,7 @@ ShallowWrapper {
           </div>,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11294,7 +10768,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11325,7 +10799,7 @@ ShallowWrapper {
           />,
           <FieldArray
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11336,7 +10810,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11363,7 +10837,7 @@ ShallowWrapper {
           />,
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -11409,24 +10883,7 @@ ShallowWrapper {
               No
             </div>
           </div>,
-          <ButtonToolbar
-            className=""
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />
-          </ButtonToolbar>,
+          false,
         ],
         "expandedTitle": undefined,
         "iconId": "collapsible-icon-test-course",
@@ -11503,7 +10960,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "min": "2001-01-01",
               "onInvalid": [Function],
@@ -11546,7 +11003,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "Start date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 Start on a Tuesday, Wednesday, or Thursday.
@@ -11578,7 +11035,7 @@ ShallowWrapper {
           "props": Object {
             "component": [Function],
             "dateLabel": "End date",
-            "disabled": false,
+            "disabled": true,
             "helpText": <div>
               <p>
                 If you are unsure of the exact date, specify a day that is close to the estimated end date. For example, if your course will end near the end of March, specify March 31.
@@ -11609,7 +11066,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -11670,7 +11127,7 @@ ShallowWrapper {
             "component": [Function],
             "courseRunKey": undefined,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -11694,7 +11151,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -11728,7 +11185,7 @@ ShallowWrapper {
               >
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -11769,7 +11226,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -11806,7 +11263,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 0,
@@ -11843,7 +11300,7 @@ ShallowWrapper {
               "props": Object {
                 "children": <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 168,
@@ -11880,7 +11337,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 168,
                     "min": 1,
@@ -11919,7 +11376,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -11951,7 +11408,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -11994,7 +11451,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -12011,7 +11468,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -12043,7 +11500,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "component": [Function],
-            "disabled": false,
+            "disabled": true,
             "extraInput": Object {
               "onInvalid": [Function],
             },
@@ -12132,49 +11589,7 @@ ShallowWrapper {
           ],
           "type": "div",
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "default": "Submit Run for Review",
-                  "pending": "Submitting Run for Review",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="default"
-            />,
-            "className": "",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "default": "Submit Run for Review",
-                "pending": "Submitting Run for Review",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "default",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        false,
       ],
       "type": [Function],
     },

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -16,7 +16,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -676,6 +676,7 @@ ShallowWrapper {
     currentFormValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -695,6 +696,7 @@ ShallowWrapper {
         "videoSrc": "https://www.video.src/watch?v=fdsafd",
       }
     }
+    editable={false}
     entitlement={
       Object {
         "mode": "verified",
@@ -772,7 +774,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -846,7 +848,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -897,7 +899,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "max": 10000,
@@ -923,7 +925,7 @@ ShallowWrapper {
           <Field
             className="course-image"
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -980,7 +982,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1042,7 +1044,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1099,7 +1101,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1158,7 +1160,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1229,7 +1231,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1282,7 +1284,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1330,7 +1332,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1385,7 +1387,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1449,7 +1451,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1512,7 +1514,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1557,7 +1559,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -1623,7 +1625,7 @@ ShallowWrapper {
             Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -2285,6 +2287,7 @@ ShallowWrapper {
           currentFormValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -2304,6 +2307,7 @@ ShallowWrapper {
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             }
           }
+          editable={false}
           entitlement={
             Object {
               "mode": "verified",
@@ -2920,39 +2924,7 @@ ShallowWrapper {
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
         />
-        <Link
-          replace={false}
-          to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-        >
-          <button
-            className="btn btn-block rounded mt-3 new-run-button"
-            disabled={false}
-          >
-            <withDeprecatedProps(Icon)
-              className="fa fa-plus"
-            />
-             Add Course Run
-          </button>
-        </Link>
-        <ButtonToolbar
-          className="mt-3"
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="complete"
-          />
-        </ButtonToolbar>
+        
       </form>,
       "className": "edit-course-form",
     },
@@ -3000,7 +2972,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3074,7 +3046,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3125,7 +3097,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -3151,7 +3123,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3208,7 +3180,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3270,7 +3242,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3327,7 +3299,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3386,7 +3358,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3457,7 +3429,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3510,7 +3482,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3558,7 +3530,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3613,7 +3585,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3677,7 +3649,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3740,7 +3712,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3785,7 +3757,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -3851,7 +3823,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -4513,6 +4485,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -4532,6 +4505,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -5148,39 +5122,8 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />,
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>,
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>,
+          "",
+          false,
         ],
         "id": "edit-course-form",
         "onSubmit": [Function],
@@ -5221,7 +5164,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5295,7 +5238,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5346,7 +5289,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -5372,7 +5315,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5429,7 +5372,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5491,7 +5434,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5548,7 +5491,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5607,7 +5550,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5678,7 +5621,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5731,7 +5674,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5779,7 +5722,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5836,7 +5779,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5900,7 +5843,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -5963,7 +5906,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -6008,7 +5951,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -6105,7 +6048,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6222,7 +6165,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6275,7 +6218,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 10000,
                   "min": 1,
@@ -6305,7 +6248,7 @@ ShallowWrapper {
               "props": Object {
                 "className": "course-image",
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6374,7 +6317,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6440,7 +6383,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6501,7 +6444,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6564,7 +6507,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6639,7 +6582,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6696,7 +6639,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6748,7 +6691,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6817,7 +6760,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6883,7 +6826,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6948,7 +6891,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -6995,7 +6938,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -7070,7 +7013,7 @@ ShallowWrapper {
             "courseOptions": Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -7726,6 +7669,7 @@ ShallowWrapper {
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -7744,6 +7688,7 @@ ShallowWrapper {
               "uuid": "11111111-1111-1111-1111-111111111111",
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             },
+            "editable": false,
             "entitlement": Object {
               "mode": "verified",
               "price": "77",
@@ -8354,102 +8299,8 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>,
-            "replace": false,
-            "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />,
-                " Add Course Run",
-              ],
-              "className": "btn btn-block rounded mt-3 new-run-button",
-              "disabled": false,
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "fa fa-plus",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              " Add Course Run",
-            ],
-            "type": "button",
-          },
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />,
-            "className": "mt-3",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "complete",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        "",
+        false,
       ],
       "type": "form",
     },
@@ -8502,7 +8353,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8576,7 +8427,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8627,7 +8478,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -8653,7 +8504,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8710,7 +8561,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8772,7 +8623,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8829,7 +8680,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8888,7 +8739,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -8959,7 +8810,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9012,7 +8863,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9060,7 +8911,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9115,7 +8966,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9179,7 +9030,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9242,7 +9093,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9287,7 +9138,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -9353,7 +9204,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -10015,6 +9866,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -10034,6 +9886,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -10650,39 +10503,7 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>
+          
         </form>,
         "className": "edit-course-form",
       },
@@ -10730,7 +10551,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -10804,7 +10625,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -10855,7 +10676,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -10881,7 +10702,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -10938,7 +10759,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11000,7 +10821,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11057,7 +10878,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11116,7 +10937,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11187,7 +11008,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11240,7 +11061,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11288,7 +11109,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11343,7 +11164,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11407,7 +11228,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11470,7 +11291,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11515,7 +11336,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -11581,7 +11402,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -12243,6 +12064,7 @@ ShallowWrapper {
               currentFormValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -12262,6 +12084,7 @@ ShallowWrapper {
                   "videoSrc": "https://www.video.src/watch?v=fdsafd",
                 }
               }
+              editable={false}
               entitlement={
                 Object {
                   "mode": "verified",
@@ -12878,39 +12701,8 @@ ShallowWrapper {
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
             />,
-            <Link
-              replace={false}
-              to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-            >
-              <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>
-            </Link>,
-            <ButtonToolbar
-              className="mt-3"
-              leftJustify={false}
-            >
-              <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />
-            </ButtonToolbar>,
+            "",
+            false,
           ],
           "id": "edit-course-form",
           "onSubmit": [Function],
@@ -12951,7 +12743,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13025,7 +12817,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13076,7 +12868,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 10000,
@@ -13102,7 +12894,7 @@ ShallowWrapper {
                 <Field
                   className="course-image"
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13159,7 +12951,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13221,7 +13013,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13278,7 +13070,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13337,7 +13129,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13408,7 +13200,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13461,7 +13253,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13509,7 +13301,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13566,7 +13358,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13630,7 +13422,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13693,7 +13485,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13738,7 +13530,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -13835,7 +13627,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -13952,7 +13744,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14005,7 +13797,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 10000,
                     "min": 1,
@@ -14035,7 +13827,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "course-image",
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14104,7 +13896,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14170,7 +13962,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14231,7 +14023,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14294,7 +14086,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14369,7 +14161,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14426,7 +14218,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14478,7 +14270,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14547,7 +14339,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14613,7 +14405,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14678,7 +14470,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14725,7 +14517,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -14800,7 +14592,7 @@ ShallowWrapper {
               "courseOptions": Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -15456,6 +15248,7 @@ ShallowWrapper {
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -15474,6 +15267,7 @@ ShallowWrapper {
                 "uuid": "11111111-1111-1111-1111-111111111111",
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               },
+              "editable": false,
               "entitlement": Object {
                 "mode": "verified",
                 "price": "77",
@@ -16084,102 +15878,8 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "children": <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>,
-              "replace": false,
-              "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <withDeprecatedProps(Icon)
-                    className="fa fa-plus"
-                  />,
-                  " Add Course Run",
-                ],
-                "className": "btn btn-block rounded mt-3 new-run-button",
-                "disabled": false,
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "className": "fa fa-plus",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                " Add Course Run",
-              ],
-              "type": "button",
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />,
-              "className": "mt-3",
-              "leftJustify": false,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "className": "",
-                "disabled": false,
-                "labels": Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                },
-                "onClick": [Function],
-                "primary": true,
-                "state": "complete",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          "",
+          false,
         ],
         "type": "form",
       },
@@ -16229,7 +15929,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -16889,6 +16589,7 @@ ShallowWrapper {
     currentFormValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -16908,6 +16609,7 @@ ShallowWrapper {
         "videoSrc": "https://www.video.src/watch?v=fdsafd",
       }
     }
+    editable={false}
     entitlement={
       Object {
         "mode": "verified",
@@ -16919,6 +16621,7 @@ ShallowWrapper {
     initialValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -17001,7 +16704,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17075,7 +16778,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17126,7 +16829,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "max": 10000,
@@ -17152,7 +16855,7 @@ ShallowWrapper {
           <Field
             className="course-image"
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17209,7 +16912,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17271,7 +16974,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17328,7 +17031,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17387,7 +17090,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17458,7 +17161,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17511,7 +17214,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17559,7 +17262,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17614,7 +17317,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17678,7 +17381,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17741,7 +17444,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17786,7 +17489,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -17852,7 +17555,7 @@ ShallowWrapper {
             Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -18514,6 +18217,7 @@ ShallowWrapper {
           currentFormValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -18533,6 +18237,7 @@ ShallowWrapper {
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             }
           }
+          editable={false}
           entitlement={
             Object {
               "mode": "verified",
@@ -18545,6 +18250,7 @@ ShallowWrapper {
           initialValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -19165,36 +18871,7 @@ ShallowWrapper {
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
         />
-        <React.Fragment>
-          <button
-            className="btn btn-block rounded mt-3 new-run-button"
-            disabled={true}
-          >
-            <withDeprecatedProps(Icon)
-              className="fa fa-plus"
-            />
-             Add Course Run
-          </button>
-        </React.Fragment>
-        <ButtonToolbar
-          className="mt-3"
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={true}
-            labels={
-              Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="pending"
-          />
-        </ButtonToolbar>
+        
       </form>,
       "className": "edit-course-form",
     },
@@ -19242,7 +18919,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19316,7 +18993,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19367,7 +19044,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -19393,7 +19070,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19450,7 +19127,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19512,7 +19189,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19569,7 +19246,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19628,7 +19305,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19699,7 +19376,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19752,7 +19429,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19800,7 +19477,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19855,7 +19532,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19919,7 +19596,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -19982,7 +19659,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -20027,7 +19704,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -20093,7 +19770,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -20755,6 +20432,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -20774,6 +20452,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -20786,6 +20465,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -21406,36 +21086,8 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />,
-          <React.Fragment>
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={true}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </React.Fragment>,
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={true}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="pending"
-            />
-          </ButtonToolbar>,
+          "",
+          false,
         ],
         "id": "edit-course-form",
         "onSubmit": [Function],
@@ -21476,7 +21128,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21550,7 +21202,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21601,7 +21253,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -21627,7 +21279,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21684,7 +21336,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21746,7 +21398,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21803,7 +21455,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21862,7 +21514,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21933,7 +21585,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -21986,7 +21638,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22034,7 +21686,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22091,7 +21743,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22155,7 +21807,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22218,7 +21870,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22263,7 +21915,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -22360,7 +22012,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22477,7 +22129,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22530,7 +22182,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 10000,
                   "min": 1,
@@ -22560,7 +22212,7 @@ ShallowWrapper {
               "props": Object {
                 "className": "course-image",
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22629,7 +22281,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22695,7 +22347,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22756,7 +22408,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22819,7 +22471,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22894,7 +22546,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -22951,7 +22603,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23003,7 +22655,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23072,7 +22724,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23138,7 +22790,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23203,7 +22855,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23250,7 +22902,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -23325,7 +22977,7 @@ ShallowWrapper {
             "courseOptions": Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -23981,6 +23633,7 @@ ShallowWrapper {
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -23999,6 +23652,7 @@ ShallowWrapper {
               "uuid": "11111111-1111-1111-1111-111111111111",
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             },
+            "editable": false,
             "entitlement": Object {
               "mode": "verified",
               "price": "77",
@@ -24008,6 +23662,7 @@ ShallowWrapper {
             "id": "edit-course-form",
             "initialValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -24625,100 +24280,8 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={true}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />,
-                " Add Course Run",
-              ],
-              "className": "btn btn-block rounded mt-3 new-run-button",
-              "disabled": true,
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "fa fa-plus",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              " Add Course Run",
-            ],
-            "type": "button",
-          },
-          "type": Symbol(react.fragment),
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={true}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="pending"
-            />,
-            "className": "mt-3",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": true,
-              "labels": Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "pending",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        "",
+        false,
       ],
       "type": "form",
     },
@@ -24771,7 +24334,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -24845,7 +24408,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -24896,7 +24459,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -24922,7 +24485,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -24979,7 +24542,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25041,7 +24604,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25098,7 +24661,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25157,7 +24720,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25228,7 +24791,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25281,7 +24844,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25329,7 +24892,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25384,7 +24947,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25448,7 +25011,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25511,7 +25074,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25556,7 +25119,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -25622,7 +25185,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -26284,6 +25847,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -26303,6 +25867,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -26315,6 +25880,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -26935,36 +26501,7 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />
-          <React.Fragment>
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={true}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </React.Fragment>
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={true}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="pending"
-            />
-          </ButtonToolbar>
+          
         </form>,
         "className": "edit-course-form",
       },
@@ -27012,7 +26549,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27086,7 +26623,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27137,7 +26674,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -27163,7 +26700,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27220,7 +26757,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27282,7 +26819,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27339,7 +26876,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27398,7 +26935,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27469,7 +27006,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27522,7 +27059,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27570,7 +27107,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27625,7 +27162,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27689,7 +27226,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27752,7 +27289,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27797,7 +27334,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -27863,7 +27400,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -28525,6 +28062,7 @@ ShallowWrapper {
               currentFormValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -28544,6 +28082,7 @@ ShallowWrapper {
                   "videoSrc": "https://www.video.src/watch?v=fdsafd",
                 }
               }
+              editable={false}
               entitlement={
                 Object {
                   "mode": "verified",
@@ -28556,6 +28095,7 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -29176,36 +28716,8 @@ ShallowWrapper {
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
             />,
-            <React.Fragment>
-              <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={true}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>
-            </React.Fragment>,
-            <ButtonToolbar
-              className="mt-3"
-              leftJustify={false}
-            >
-              <ActionButton
-                className=""
-                disabled={true}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="pending"
-              />
-            </ButtonToolbar>,
+            "",
+            false,
           ],
           "id": "edit-course-form",
           "onSubmit": [Function],
@@ -29246,7 +28758,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29320,7 +28832,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29371,7 +28883,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 10000,
@@ -29397,7 +28909,7 @@ ShallowWrapper {
                 <Field
                   className="course-image"
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29454,7 +28966,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29516,7 +29028,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29573,7 +29085,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29632,7 +29144,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29703,7 +29215,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29756,7 +29268,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29804,7 +29316,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29861,7 +29373,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29925,7 +29437,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -29988,7 +29500,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -30033,7 +29545,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -30130,7 +29642,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30247,7 +29759,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30300,7 +29812,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 10000,
                     "min": 1,
@@ -30330,7 +29842,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "course-image",
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30399,7 +29911,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30465,7 +29977,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30526,7 +30038,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30589,7 +30101,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30664,7 +30176,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30721,7 +30233,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30773,7 +30285,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30842,7 +30354,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30908,7 +30420,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -30973,7 +30485,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -31020,7 +30532,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -31095,7 +30607,7 @@ ShallowWrapper {
               "courseOptions": Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -31751,6 +31263,7 @@ ShallowWrapper {
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -31769,6 +31282,7 @@ ShallowWrapper {
                 "uuid": "11111111-1111-1111-1111-111111111111",
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               },
+              "editable": false,
               "entitlement": Object {
                 "mode": "verified",
                 "price": "77",
@@ -31778,6 +31292,7 @@ ShallowWrapper {
               "id": "edit-course-form",
               "initialValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -32395,100 +31910,8 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={true}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <withDeprecatedProps(Icon)
-                    className="fa fa-plus"
-                  />,
-                  " Add Course Run",
-                ],
-                "className": "btn btn-block rounded mt-3 new-run-button",
-                "disabled": true,
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "className": "fa fa-plus",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                " Add Course Run",
-              ],
-              "type": "button",
-            },
-            "type": Symbol(react.fragment),
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <ActionButton
-                className=""
-                disabled={true}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="pending"
-              />,
-              "className": "mt-3",
-              "leftJustify": false,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "className": "",
-                "disabled": true,
-                "labels": Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                },
-                "onClick": [Function],
-                "primary": true,
-                "state": "pending",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          "",
+          false,
         ],
         "type": "form",
       },
@@ -32538,7 +31961,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -33198,6 +32621,7 @@ ShallowWrapper {
     currentFormValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -33217,6 +32641,7 @@ ShallowWrapper {
         "videoSrc": "https://www.video.src/watch?v=fdsafd",
       }
     }
+    editable={false}
     entitlement={
       Object {
         "mode": "verified",
@@ -33228,6 +32653,7 @@ ShallowWrapper {
     initialValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -33310,7 +32736,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33384,7 +32810,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33435,7 +32861,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "max": 10000,
@@ -33461,7 +32887,7 @@ ShallowWrapper {
           <Field
             className="course-image"
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33518,7 +32944,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33580,7 +33006,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33637,7 +33063,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33696,7 +33122,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33767,7 +33193,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33820,7 +33246,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33868,7 +33294,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33922,7 +33348,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -33950,7 +33376,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -34025,7 +33451,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -34089,7 +33515,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -34152,7 +33578,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -34197,7 +33623,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -34263,7 +33689,7 @@ ShallowWrapper {
             Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -34925,6 +34351,7 @@ ShallowWrapper {
           currentFormValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -34944,6 +34371,7 @@ ShallowWrapper {
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             }
           }
+          editable={false}
           entitlement={
             Object {
               "mode": "verified",
@@ -34956,6 +34384,7 @@ ShallowWrapper {
           initialValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -35576,39 +35005,7 @@ ShallowWrapper {
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
         />
-        <Link
-          replace={false}
-          to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-        >
-          <button
-            className="btn btn-block rounded mt-3 new-run-button"
-            disabled={false}
-          >
-            <withDeprecatedProps(Icon)
-              className="fa fa-plus"
-            />
-             Add Course Run
-          </button>
-        </Link>
-        <ButtonToolbar
-          className="mt-3"
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="complete"
-          />
-        </ButtonToolbar>
+        
       </form>,
       "className": "edit-course-form",
     },
@@ -35656,7 +35053,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -35730,7 +35127,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -35781,7 +35178,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -35807,7 +35204,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -35864,7 +35261,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -35926,7 +35323,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -35983,7 +35380,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36042,7 +35439,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36113,7 +35510,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36166,7 +35563,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36214,7 +35611,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36268,7 +35665,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36296,7 +35693,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36371,7 +35768,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36435,7 +35832,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36498,7 +35895,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36543,7 +35940,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -36609,7 +36006,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -37271,6 +36668,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -37290,6 +36688,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -37302,6 +36701,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -37922,39 +37322,8 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />,
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>,
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>,
+          "",
+          false,
         ],
         "id": "edit-course-form",
         "onSubmit": [Function],
@@ -37995,7 +37364,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38069,7 +37438,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38120,7 +37489,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -38146,7 +37515,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38203,7 +37572,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38265,7 +37634,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38322,7 +37691,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38381,7 +37750,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38452,7 +37821,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38505,7 +37874,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38553,7 +37922,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38607,7 +37976,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38635,7 +38004,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38710,7 +38079,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38774,7 +38143,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38837,7 +38206,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38882,7 +38251,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -38979,7 +38348,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39096,7 +38465,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39149,7 +38518,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 10000,
                   "min": 1,
@@ -39179,7 +38548,7 @@ ShallowWrapper {
               "props": Object {
                 "className": "course-image",
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39248,7 +38617,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39314,7 +38683,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39375,7 +38744,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39438,7 +38807,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39513,7 +38882,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39570,7 +38939,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39622,7 +38991,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39680,7 +39049,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39712,7 +39081,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39799,7 +39168,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39865,7 +39234,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39930,7 +39299,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -39977,7 +39346,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -40052,7 +39421,7 @@ ShallowWrapper {
             "courseOptions": Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -40708,6 +40077,7 @@ ShallowWrapper {
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -40726,6 +40096,7 @@ ShallowWrapper {
               "uuid": "11111111-1111-1111-1111-111111111111",
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             },
+            "editable": false,
             "entitlement": Object {
               "mode": "verified",
               "price": "77",
@@ -40735,6 +40106,7 @@ ShallowWrapper {
             "id": "edit-course-form",
             "initialValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -41352,102 +40724,8 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>,
-            "replace": false,
-            "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />,
-                " Add Course Run",
-              ],
-              "className": "btn btn-block rounded mt-3 new-run-button",
-              "disabled": false,
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "fa fa-plus",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              " Add Course Run",
-            ],
-            "type": "button",
-          },
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />,
-            "className": "mt-3",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "complete",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        "",
+        false,
       ],
       "type": "form",
     },
@@ -41500,7 +40778,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41574,7 +40852,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41625,7 +40903,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -41651,7 +40929,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41708,7 +40986,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41770,7 +41048,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41827,7 +41105,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41886,7 +41164,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -41957,7 +41235,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42010,7 +41288,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42058,7 +41336,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42112,7 +41390,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42140,7 +41418,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42215,7 +41493,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42279,7 +41557,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42342,7 +41620,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42387,7 +41665,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -42453,7 +41731,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -43115,6 +42393,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -43134,6 +42413,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -43146,6 +42426,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -43766,39 +43047,7 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>
+          
         </form>,
         "className": "edit-course-form",
       },
@@ -43846,7 +43095,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -43920,7 +43169,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -43971,7 +43220,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -43997,7 +43246,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44054,7 +43303,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44116,7 +43365,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44173,7 +43422,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44232,7 +43481,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44303,7 +43552,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44356,7 +43605,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44404,7 +43653,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44458,7 +43707,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44486,7 +43735,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44561,7 +43810,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44625,7 +43874,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44688,7 +43937,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44733,7 +43982,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -44799,7 +44048,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -45461,6 +44710,7 @@ ShallowWrapper {
               currentFormValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -45480,6 +44730,7 @@ ShallowWrapper {
                   "videoSrc": "https://www.video.src/watch?v=fdsafd",
                 }
               }
+              editable={false}
               entitlement={
                 Object {
                   "mode": "verified",
@@ -45492,6 +44743,7 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -46112,39 +45364,8 @@ ShallowWrapper {
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
             />,
-            <Link
-              replace={false}
-              to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-            >
-              <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>
-            </Link>,
-            <ButtonToolbar
-              className="mt-3"
-              leftJustify={false}
-            >
-              <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />
-            </ButtonToolbar>,
+            "",
+            false,
           ],
           "id": "edit-course-form",
           "onSubmit": [Function],
@@ -46185,7 +45406,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46259,7 +45480,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46310,7 +45531,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 10000,
@@ -46336,7 +45557,7 @@ ShallowWrapper {
                 <Field
                   className="course-image"
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46393,7 +45614,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46455,7 +45676,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46512,7 +45733,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46571,7 +45792,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46642,7 +45863,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46695,7 +45916,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46743,7 +45964,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46797,7 +46018,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46825,7 +46046,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46900,7 +46121,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -46964,7 +46185,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -47027,7 +46248,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -47072,7 +46293,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -47169,7 +46390,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47286,7 +46507,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47339,7 +46560,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 10000,
                     "min": 1,
@@ -47369,7 +46590,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "course-image",
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47438,7 +46659,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47504,7 +46725,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47565,7 +46786,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47628,7 +46849,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47703,7 +46924,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47760,7 +46981,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47812,7 +47033,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47870,7 +47091,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47902,7 +47123,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -47989,7 +47210,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -48055,7 +47276,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -48120,7 +47341,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -48167,7 +47388,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -48242,7 +47463,7 @@ ShallowWrapper {
               "courseOptions": Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -48898,6 +48119,7 @@ ShallowWrapper {
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -48916,6 +48138,7 @@ ShallowWrapper {
                 "uuid": "11111111-1111-1111-1111-111111111111",
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               },
+              "editable": false,
               "entitlement": Object {
                 "mode": "verified",
                 "price": "77",
@@ -48925,6 +48148,7 @@ ShallowWrapper {
               "id": "edit-course-form",
               "initialValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -49542,102 +48766,8 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "children": <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>,
-              "replace": false,
-              "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <withDeprecatedProps(Icon)
-                    className="fa fa-plus"
-                  />,
-                  " Add Course Run",
-                ],
-                "className": "btn btn-block rounded mt-3 new-run-button",
-                "disabled": false,
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "className": "fa fa-plus",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                " Add Course Run",
-              ],
-              "type": "button",
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />,
-              "className": "mt-3",
-              "leftJustify": false,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "className": "",
-                "disabled": false,
-                "labels": Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                },
-                "onClick": [Function],
-                "primary": true,
-                "state": "complete",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          "",
+          false,
         ],
         "type": "form",
       },
@@ -49687,7 +48817,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -50347,6 +49477,7 @@ ShallowWrapper {
     currentFormValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -50366,6 +49497,7 @@ ShallowWrapper {
         "videoSrc": "https://www.video.src/watch?v=fdsafd",
       }
     }
+    editable={false}
     entitlement={
       Object {
         "mode": "verified",
@@ -50377,6 +49509,7 @@ ShallowWrapper {
     initialValues={
       Object {
         "additional_information": "additional info",
+        "editable": true,
         "faq": "frequently asked questions",
         "full_description": "long desc",
         "imageSrc": "http://image.src.small",
@@ -50459,7 +49592,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50533,7 +49666,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50584,7 +49717,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "max": 10000,
@@ -50610,7 +49743,7 @@ ShallowWrapper {
           <Field
             className="course-image"
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50667,7 +49800,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50729,7 +49862,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50786,7 +49919,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50845,7 +49978,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50916,7 +50049,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -50969,7 +50102,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51017,7 +50150,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51072,7 +50205,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51136,7 +50269,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51199,7 +50332,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51244,7 +50377,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -51310,7 +50443,7 @@ ShallowWrapper {
             Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -51972,6 +51105,7 @@ ShallowWrapper {
           currentFormValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -51991,6 +51125,7 @@ ShallowWrapper {
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             }
           }
+          editable={false}
           entitlement={
             Object {
               "mode": "verified",
@@ -52003,6 +51138,7 @@ ShallowWrapper {
           initialValues={
             Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -52623,39 +51759,7 @@ ShallowWrapper {
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
         />
-        <Link
-          replace={false}
-          to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-        >
-          <button
-            className="btn btn-block rounded mt-3 new-run-button"
-            disabled={false}
-          >
-            <withDeprecatedProps(Icon)
-              className="fa fa-plus"
-            />
-             Add Course Run
-          </button>
-        </Link>
-        <ButtonToolbar
-          className="mt-3"
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="complete"
-          />
-        </ButtonToolbar>
+        
       </form>,
       "className": "edit-course-form",
     },
@@ -52703,7 +51807,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -52777,7 +51881,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -52828,7 +51932,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -52854,7 +51958,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -52911,7 +52015,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -52973,7 +52077,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53030,7 +52134,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53089,7 +52193,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53160,7 +52264,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53213,7 +52317,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53261,7 +52365,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53316,7 +52420,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53380,7 +52484,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53443,7 +52547,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53488,7 +52592,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -53554,7 +52658,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -54216,6 +53320,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -54235,6 +53340,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -54247,6 +53353,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -54867,39 +53974,8 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />,
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>,
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>,
+          "",
+          false,
         ],
         "id": "edit-course-form",
         "onSubmit": [Function],
@@ -54940,7 +54016,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55014,7 +54090,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55065,7 +54141,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -55091,7 +54167,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55148,7 +54224,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55210,7 +54286,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55267,7 +54343,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55326,7 +54402,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55397,7 +54473,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55450,7 +54526,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55498,7 +54574,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55555,7 +54631,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55619,7 +54695,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55682,7 +54758,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55727,7 +54803,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -55824,7 +54900,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -55941,7 +55017,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -55994,7 +55070,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "max": 10000,
                   "min": 1,
@@ -56024,7 +55100,7 @@ ShallowWrapper {
               "props": Object {
                 "className": "course-image",
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56093,7 +55169,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56159,7 +55235,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56220,7 +55296,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56283,7 +55359,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56358,7 +55434,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56415,7 +55491,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56467,7 +55543,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56536,7 +55612,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56602,7 +55678,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56667,7 +55743,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56714,7 +55790,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -56789,7 +55865,7 @@ ShallowWrapper {
             "courseOptions": Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -57445,6 +56521,7 @@ ShallowWrapper {
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -57463,6 +56540,7 @@ ShallowWrapper {
               "uuid": "11111111-1111-1111-1111-111111111111",
               "videoSrc": "https://www.video.src/watch?v=fdsafd",
             },
+            "editable": false,
             "entitlement": Object {
               "mode": "verified",
               "price": "77",
@@ -57472,6 +56550,7 @@ ShallowWrapper {
             "id": "edit-course-form",
             "initialValues": Object {
               "additional_information": "additional info",
+              "editable": true,
               "faq": "frequently asked questions",
               "full_description": "long desc",
               "imageSrc": "http://image.src.small",
@@ -58089,102 +57168,8 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>,
-            "replace": false,
-            "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />,
-                " Add Course Run",
-              ],
-              "className": "btn btn-block rounded mt-3 new-run-button",
-              "disabled": false,
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "fa fa-plus",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              " Add Course Run",
-            ],
-            "type": "button",
-          },
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />,
-            "className": "mt-3",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "complete",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        "",
+        false,
       ],
       "type": "form",
     },
@@ -58237,7 +57222,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58311,7 +57296,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58362,7 +57347,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "max": 10000,
@@ -58388,7 +57373,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58445,7 +57430,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58507,7 +57492,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58564,7 +57549,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58623,7 +57608,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58694,7 +57679,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58747,7 +57732,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58795,7 +57780,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58850,7 +57835,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58914,7 +57899,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -58977,7 +57962,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -59022,7 +58007,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -59088,7 +58073,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -59750,6 +58735,7 @@ ShallowWrapper {
             currentFormValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -59769,6 +58755,7 @@ ShallowWrapper {
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               }
             }
+            editable={false}
             entitlement={
               Object {
                 "mode": "verified",
@@ -59781,6 +58768,7 @@ ShallowWrapper {
             initialValues={
               Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -60401,39 +59389,7 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>
+          
         </form>,
         "className": "edit-course-form",
       },
@@ -60481,7 +59437,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60555,7 +59511,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60606,7 +59562,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "max": 10000,
@@ -60632,7 +59588,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60689,7 +59645,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60751,7 +59707,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60808,7 +59764,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60867,7 +59823,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60938,7 +59894,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -60991,7 +59947,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61039,7 +59995,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61094,7 +60050,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61158,7 +60114,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61221,7 +60177,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61266,7 +60222,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -61332,7 +60288,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -61994,6 +60950,7 @@ ShallowWrapper {
               currentFormValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -62013,6 +60970,7 @@ ShallowWrapper {
                   "videoSrc": "https://www.video.src/watch?v=fdsafd",
                 }
               }
+              editable={false}
               entitlement={
                 Object {
                   "mode": "verified",
@@ -62025,6 +60983,7 @@ ShallowWrapper {
               initialValues={
                 Object {
                   "additional_information": "additional info",
+                  "editable": true,
                   "faq": "frequently asked questions",
                   "full_description": "long desc",
                   "imageSrc": "http://image.src.small",
@@ -62645,39 +61604,8 @@ ShallowWrapper {
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
             />,
-            <Link
-              replace={false}
-              to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-            >
-              <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>
-            </Link>,
-            <ButtonToolbar
-              className="mt-3"
-              leftJustify={false}
-            >
-              <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />
-            </ButtonToolbar>,
+            "",
+            false,
           ],
           "id": "edit-course-form",
           "onSubmit": [Function],
@@ -62718,7 +61646,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -62792,7 +61720,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -62843,7 +61771,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "max": 10000,
@@ -62869,7 +61797,7 @@ ShallowWrapper {
                 <Field
                   className="course-image"
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -62926,7 +61854,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -62988,7 +61916,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63045,7 +61973,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63104,7 +62032,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63175,7 +62103,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63228,7 +62156,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63276,7 +62204,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63333,7 +62261,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63397,7 +62325,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63460,7 +62388,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63505,7 +62433,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -63602,7 +62530,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -63719,7 +62647,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -63772,7 +62700,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "max": 10000,
                     "min": 1,
@@ -63802,7 +62730,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "course-image",
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -63871,7 +62799,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -63937,7 +62865,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -63998,7 +62926,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64061,7 +62989,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64136,7 +63064,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64193,7 +63121,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64245,7 +63173,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64314,7 +63242,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64380,7 +63308,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64445,7 +63373,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64492,7 +63420,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -64567,7 +63495,7 @@ ShallowWrapper {
               "courseOptions": Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -65223,6 +64151,7 @@ ShallowWrapper {
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -65241,6 +64170,7 @@ ShallowWrapper {
                 "uuid": "11111111-1111-1111-1111-111111111111",
                 "videoSrc": "https://www.video.src/watch?v=fdsafd",
               },
+              "editable": false,
               "entitlement": Object {
                 "mode": "verified",
                 "price": "77",
@@ -65250,6 +64180,7 @@ ShallowWrapper {
               "id": "edit-course-form",
               "initialValues": Object {
                 "additional_information": "additional info",
+                "editable": true,
                 "faq": "frequently asked questions",
                 "full_description": "long desc",
                 "imageSrc": "http://image.src.small",
@@ -65867,102 +64798,8 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "children": <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>,
-              "replace": false,
-              "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <withDeprecatedProps(Icon)
-                    className="fa fa-plus"
-                  />,
-                  " Add Course Run",
-                ],
-                "className": "btn btn-block rounded mt-3 new-run-button",
-                "disabled": false,
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "className": "fa fa-plus",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                " Add Course Run",
-              ],
-              "type": "button",
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />,
-              "className": "mt-3",
-              "leftJustify": false,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "className": "",
-                "disabled": false,
-                "labels": Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                },
-                "onClick": [Function],
-                "primary": true,
-                "state": "complete",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          "",
+          false,
         ],
         "type": "form",
       },
@@ -66012,7 +64849,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -66670,6 +65507,7 @@ ShallowWrapper {
     }
     courseSubmitInfo={Object {}}
     currentFormValues={Object {}}
+    editable={false}
     entitlement={
       Object {
         "sku": null,
@@ -66745,7 +65583,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -66819,7 +65657,7 @@ ShallowWrapper {
           </div>
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -66871,7 +65709,7 @@ ShallowWrapper {
           <Field
             className="course-image"
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -66928,7 +65766,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -66990,7 +65828,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67047,7 +65885,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67106,7 +65944,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67177,7 +66015,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67230,7 +66068,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67278,7 +66116,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67333,7 +66171,7 @@ ShallowWrapper {
           <hr />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67397,7 +66235,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67460,7 +66298,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67505,7 +66343,7 @@ ShallowWrapper {
           />
           <Field
             component={[Function]}
-            disabled={false}
+            disabled={true}
             extraInput={
               Object {
                 "onInvalid": [Function],
@@ -67571,7 +66409,7 @@ ShallowWrapper {
             Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -68231,6 +67069,7 @@ ShallowWrapper {
           courseSubmitting={false}
           courseUuid="11111111-1111-1111-1111-111111111111"
           currentFormValues={Object {}}
+          editable={false}
           entitlement={
             Object {
               "sku": null,
@@ -68845,39 +67684,7 @@ ShallowWrapper {
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
         />
-        <Link
-          replace={false}
-          to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-        >
-          <button
-            className="btn btn-block rounded mt-3 new-run-button"
-            disabled={false}
-          >
-            <withDeprecatedProps(Icon)
-              className="fa fa-plus"
-            />
-             Add Course Run
-          </button>
-        </Link>
-        <ButtonToolbar
-          className="mt-3"
-          leftJustify={false}
-        >
-          <ActionButton
-            className=""
-            disabled={false}
-            labels={
-              Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              }
-            }
-            onClick={[Function]}
-            primary={true}
-            state="complete"
-          />
-        </ButtonToolbar>
+        
       </form>,
       "className": "edit-course-form",
     },
@@ -68925,7 +67732,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -68999,7 +67806,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69051,7 +67858,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69108,7 +67915,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69170,7 +67977,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69227,7 +68034,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69286,7 +68093,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69357,7 +68164,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69410,7 +68217,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69458,7 +68265,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69513,7 +68320,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69577,7 +68384,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69640,7 +68447,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69685,7 +68492,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -69751,7 +68558,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -70411,6 +69218,7 @@ ShallowWrapper {
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={Object {}}
+            editable={false}
             entitlement={
               Object {
                 "sku": null,
@@ -71025,39 +69833,8 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />,
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>,
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>,
+          "",
+          false,
         ],
         "id": "edit-course-form",
         "onSubmit": [Function],
@@ -71098,7 +69875,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71172,7 +69949,7 @@ ShallowWrapper {
               </div>,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71225,7 +70002,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71282,7 +70059,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71344,7 +70121,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71401,7 +70178,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71460,7 +70237,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71531,7 +70308,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71584,7 +70361,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71632,7 +70409,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71689,7 +70466,7 @@ ShallowWrapper {
               <hr />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71753,7 +70530,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71816,7 +70593,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71861,7 +70638,7 @@ ShallowWrapper {
               />,
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -71958,7 +70735,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72075,7 +70852,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72130,7 +70907,7 @@ ShallowWrapper {
               "props": Object {
                 "className": "course-image",
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72199,7 +70976,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72265,7 +71042,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72326,7 +71103,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72389,7 +71166,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72464,7 +71241,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72521,7 +71298,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72573,7 +71350,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72642,7 +71419,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72708,7 +71485,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72773,7 +71550,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72820,7 +71597,7 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
-                "disabled": false,
+                "disabled": true,
                 "extraInput": Object {
                   "onInvalid": [Function],
                 },
@@ -72895,7 +71672,7 @@ ShallowWrapper {
             "courseOptions": Object {
               "data": Object {
                 "actions": Object {
-                  "PUT": Object {
+                  "POST": Object {
                     "level_type": Object {
                       "choices": Array [
                         Object {
@@ -73550,6 +72327,7 @@ ShallowWrapper {
             "courseSubmitting": false,
             "courseUuid": "11111111-1111-1111-1111-111111111111",
             "currentFormValues": Object {},
+            "editable": false,
             "entitlement": Object {
               "sku": null,
             },
@@ -74158,102 +72936,8 @@ ShallowWrapper {
           "rendered": null,
           "type": [Function],
         },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "children": <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>,
-            "replace": false,
-            "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />,
-                " Add Course Run",
-              ],
-              "className": "btn btn-block rounded mt-3 new-run-button",
-              "disabled": false,
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "className": "fa fa-plus",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              " Add Course Run",
-            ],
-            "type": "button",
-          },
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "children": <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />,
-            "className": "mt-3",
-            "leftJustify": false,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "className": "",
-              "disabled": false,
-              "labels": Object {
-                "complete": "Course Saved",
-                "default": "Save & Continue Editing",
-                "pending": "Saving Course",
-              },
-              "onClick": [Function],
-              "primary": true,
-              "state": "complete",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
-          "type": [Function],
-        },
+        "",
+        false,
       ],
       "type": "form",
     },
@@ -74306,7 +72990,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74380,7 +73064,7 @@ ShallowWrapper {
             </div>
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74432,7 +73116,7 @@ ShallowWrapper {
             <Field
               className="course-image"
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74489,7 +73173,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74551,7 +73235,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74608,7 +73292,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74667,7 +73351,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74738,7 +73422,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74791,7 +73475,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74839,7 +73523,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74894,7 +73578,7 @@ ShallowWrapper {
             <hr />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -74958,7 +73642,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -75021,7 +73705,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -75066,7 +73750,7 @@ ShallowWrapper {
             />
             <Field
               component={[Function]}
-              disabled={false}
+              disabled={true}
               extraInput={
                 Object {
                   "onInvalid": [Function],
@@ -75132,7 +73816,7 @@ ShallowWrapper {
               Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -75792,6 +74476,7 @@ ShallowWrapper {
             courseSubmitting={false}
             courseUuid="11111111-1111-1111-1111-111111111111"
             currentFormValues={Object {}}
+            editable={false}
             entitlement={
               Object {
                 "sku": null,
@@ -76406,39 +75091,7 @@ ShallowWrapper {
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
           />
-          <Link
-            replace={false}
-            to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-          >
-            <button
-              className="btn btn-block rounded mt-3 new-run-button"
-              disabled={false}
-            >
-              <withDeprecatedProps(Icon)
-                className="fa fa-plus"
-              />
-               Add Course Run
-            </button>
-          </Link>
-          <ButtonToolbar
-            className="mt-3"
-            leftJustify={false}
-          >
-            <ActionButton
-              className=""
-              disabled={false}
-              labels={
-                Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                }
-              }
-              onClick={[Function]}
-              primary={true}
-              state="complete"
-            />
-          </ButtonToolbar>
+          
         </form>,
         "className": "edit-course-form",
       },
@@ -76486,7 +75139,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76560,7 +75213,7 @@ ShallowWrapper {
               </div>
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76612,7 +75265,7 @@ ShallowWrapper {
               <Field
                 className="course-image"
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76669,7 +75322,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76731,7 +75384,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76788,7 +75441,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76847,7 +75500,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76918,7 +75571,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -76971,7 +75624,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77019,7 +75672,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77074,7 +75727,7 @@ ShallowWrapper {
               <hr />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77138,7 +75791,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77201,7 +75854,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77246,7 +75899,7 @@ ShallowWrapper {
               />
               <Field
                 component={[Function]}
-                disabled={false}
+                disabled={true}
                 extraInput={
                   Object {
                     "onInvalid": [Function],
@@ -77312,7 +75965,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -77972,6 +76625,7 @@ ShallowWrapper {
               courseSubmitting={false}
               courseUuid="11111111-1111-1111-1111-111111111111"
               currentFormValues={Object {}}
+              editable={false}
               entitlement={
                 Object {
                   "sku": null,
@@ -78586,39 +77240,8 @@ ShallowWrapper {
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
             />,
-            <Link
-              replace={false}
-              to="/courses/11111111-1111-1111-1111-111111111111/rerun"
-            >
-              <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>
-            </Link>,
-            <ButtonToolbar
-              className="mt-3"
-              leftJustify={false}
-            >
-              <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />
-            </ButtonToolbar>,
+            "",
+            false,
           ],
           "id": "edit-course-form",
           "onSubmit": [Function],
@@ -78659,7 +77282,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -78733,7 +77356,7 @@ ShallowWrapper {
                 </div>,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -78786,7 +77409,7 @@ ShallowWrapper {
                 <Field
                   className="course-image"
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -78843,7 +77466,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -78905,7 +77528,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -78962,7 +77585,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79021,7 +77644,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79092,7 +77715,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79145,7 +77768,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79193,7 +77816,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79250,7 +77873,7 @@ ShallowWrapper {
                 <hr />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79314,7 +77937,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79377,7 +78000,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79422,7 +78045,7 @@ ShallowWrapper {
                 />,
                 <Field
                   component={[Function]}
-                  disabled={false}
+                  disabled={true}
                   extraInput={
                     Object {
                       "onInvalid": [Function],
@@ -79519,7 +78142,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79636,7 +78259,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79691,7 +78314,7 @@ ShallowWrapper {
                 "props": Object {
                   "className": "course-image",
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79760,7 +78383,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79826,7 +78449,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79887,7 +78510,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -79950,7 +78573,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80025,7 +78648,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80082,7 +78705,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80134,7 +78757,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80203,7 +78826,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80269,7 +78892,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80334,7 +78957,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80381,7 +79004,7 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
-                  "disabled": false,
+                  "disabled": true,
                   "extraInput": Object {
                     "onInvalid": [Function],
                   },
@@ -80456,7 +79079,7 @@ ShallowWrapper {
               "courseOptions": Object {
                 "data": Object {
                   "actions": Object {
-                    "PUT": Object {
+                    "POST": Object {
                       "level_type": Object {
                         "choices": Array [
                           Object {
@@ -81111,6 +79734,7 @@ ShallowWrapper {
               "courseSubmitting": false,
               "courseUuid": "11111111-1111-1111-1111-111111111111",
               "currentFormValues": Object {},
+              "editable": false,
               "entitlement": Object {
                 "sku": null,
               },
@@ -81719,102 +80343,8 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "children": <button
-                className="btn btn-block rounded mt-3 new-run-button"
-                disabled={false}
-              >
-                <withDeprecatedProps(Icon)
-                  className="fa fa-plus"
-                />
-                 Add Course Run
-              </button>,
-              "replace": false,
-              "to": "/courses/11111111-1111-1111-1111-111111111111/rerun",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <withDeprecatedProps(Icon)
-                    className="fa fa-plus"
-                  />,
-                  " Add Course Run",
-                ],
-                "className": "btn btn-block rounded mt-3 new-run-button",
-                "disabled": false,
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "className": "fa fa-plus",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                " Add Course Run",
-              ],
-              "type": "button",
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "children": <ActionButton
-                className=""
-                disabled={false}
-                labels={
-                  Object {
-                    "complete": "Course Saved",
-                    "default": "Save & Continue Editing",
-                    "pending": "Saving Course",
-                  }
-                }
-                onClick={[Function]}
-                primary={true}
-                state="complete"
-              />,
-              "className": "mt-3",
-              "leftJustify": false,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "className": "",
-                "disabled": false,
-                "labels": Object {
-                  "complete": "Course Saved",
-                  "default": "Save & Continue Editing",
-                  "pending": "Saving Course",
-                },
-                "onClick": [Function],
-                "primary": true,
-                "state": "complete",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
-            "type": [Function],
-          },
+          "",
+          false,
         ],
         "type": "form",
       },

--- a/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCoursePage.test.jsx.snap
@@ -56,6 +56,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -156,6 +165,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             undefined,
@@ -214,6 +232,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           undefined,
@@ -289,6 +324,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -363,6 +399,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -463,6 +508,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               undefined,
@@ -521,6 +575,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             undefined,
@@ -596,6 +667,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -796,6 +868,7 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            false,
             <LoadingSpinner
               message="Loading…"
             />,
@@ -809,6 +882,7 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          false,
           Object {
             "instance": null,
             "key": undefined,
@@ -912,6 +986,7 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              false,
               <LoadingSpinner
                 message="Loading…"
               />,
@@ -925,6 +1000,7 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            false,
             Object {
               "instance": null,
               "key": undefined,
@@ -1086,6 +1162,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -1253,6 +1338,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             false,
@@ -1378,6 +1472,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           false,
@@ -1576,6 +1687,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {
                   "currency": "USD",
                   "expires": null,
@@ -1656,6 +1768,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -1823,6 +1944,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               false,
@@ -1948,6 +2078,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             false,
@@ -2146,6 +2293,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {
                     "currency": "USD",
                     "expires": null,
@@ -2299,7 +2447,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -2388,6 +2536,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -2458,7 +2615,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -2604,6 +2761,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             false,
@@ -2677,7 +2843,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -2778,6 +2944,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           false,
@@ -2855,7 +3038,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -3021,7 +3204,7 @@ ShallowWrapper {
                 "courseOptions": Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -3072,6 +3255,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {
                   "currency": "USD",
                   "expires": null,
@@ -3152,6 +3336,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -3222,7 +3415,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -3368,6 +3561,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               false,
@@ -3441,7 +3643,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -3542,6 +3744,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             false,
@@ -3619,7 +3838,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -3785,7 +4004,7 @@ ShallowWrapper {
                   "courseOptions": Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -3836,6 +4055,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {
                     "currency": "USD",
                     "expires": null,
@@ -3977,6 +4197,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -4096,6 +4325,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             undefined,
@@ -4172,6 +4410,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           undefined,
@@ -4255,6 +4510,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -4349,6 +4605,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -4468,6 +4733,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               undefined,
@@ -4544,6 +4818,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             undefined,
@@ -4627,6 +4918,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -4794,7 +5086,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -4951,6 +5243,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -5021,7 +5322,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -5235,6 +5536,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             false,
             undefined,
             false,
@@ -5308,7 +5618,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -5477,6 +5787,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           false,
           undefined,
           false,
@@ -5554,7 +5881,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -5788,7 +6115,7 @@ ShallowWrapper {
                 "courseOptions": Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -5905,6 +6232,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {
                   "currency": "USD",
                   "expires": null,
@@ -5985,6 +6313,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -6055,7 +6392,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -6269,6 +6606,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               false,
               undefined,
               false,
@@ -6342,7 +6688,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -6511,6 +6857,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             false,
             undefined,
             false,
@@ -6588,7 +6951,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -6822,7 +7185,7 @@ ShallowWrapper {
                   "courseOptions": Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -6939,6 +7302,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {
                     "currency": "USD",
                     "expires": null,
@@ -7096,6 +7460,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -7235,6 +7608,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             false,
             undefined,
             undefined,
@@ -7331,6 +7713,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           false,
           undefined,
           undefined,
@@ -7442,6 +7841,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -7540,6 +7940,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -7679,6 +8088,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               false,
               undefined,
               undefined,
@@ -7775,6 +8193,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             false,
             undefined,
             undefined,
@@ -7886,6 +8321,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -8001,7 +8437,7 @@ ShallowWrapper {
       Object {
         "data": Object {
           "actions": Object {
-            "PUT": Object {
+            "POST": Object {
               "level_type": Object {
                 "choices": Array [
                   Object {
@@ -8090,6 +8526,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -8104,7 +8549,7 @@ ShallowWrapper {
                 Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -8239,6 +8684,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             undefined,
@@ -8256,7 +8710,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -8346,6 +8800,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           undefined,
@@ -8367,7 +8838,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -8466,7 +8937,7 @@ ShallowWrapper {
                 "courseOptions": Object {
                   "data": Object {
                     "actions": Object {
-                      "PUT": Object {
+                      "POST": Object {
                         "level_type": Object {
                           "choices": Array [
                             Object {
@@ -8517,6 +8988,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -8591,6 +9063,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -8605,7 +9086,7 @@ ShallowWrapper {
                   Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -8740,6 +9221,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               undefined,
@@ -8757,7 +9247,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -8847,6 +9337,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             undefined,
@@ -8868,7 +9375,7 @@ ShallowWrapper {
                     Object {
                       "data": Object {
                         "actions": Object {
-                          "PUT": Object {
+                          "POST": Object {
                             "level_type": Object {
                               "choices": Array [
                                 Object {
@@ -8967,7 +9474,7 @@ ShallowWrapper {
                   "courseOptions": Object {
                     "data": Object {
                       "actions": Object {
-                        "PUT": Object {
+                        "POST": Object {
                           "level_type": Object {
                             "choices": Array [
                               Object {
@@ -9018,6 +9525,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -9157,6 +9665,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -9280,6 +9797,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             undefined,
             undefined,
             undefined,
@@ -9360,6 +9886,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           undefined,
           undefined,
           undefined,
@@ -9449,6 +9992,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -9543,6 +10087,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -9666,6 +10219,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               undefined,
               undefined,
               undefined,
@@ -9746,6 +10308,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             undefined,
             undefined,
             undefined,
@@ -9835,6 +10414,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -10054,6 +10634,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -10222,6 +10811,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             false,
             undefined,
             undefined,
@@ -10348,6 +10946,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           false,
           undefined,
           undefined,
@@ -10557,6 +11172,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -10631,6 +11247,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -10799,6 +11424,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               false,
               undefined,
               undefined,
@@ -10925,6 +11559,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             false,
             undefined,
             undefined,
@@ -11134,6 +11785,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],
@@ -11273,6 +11925,15 @@ ShallowWrapper {
           className=""
           wide={false}
         >
+          <StatusAlert
+            alertType="secondary"
+            className=""
+            dismissible={false}
+            iconClassNames={Array []}
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+            onClose={[Function]}
+            title={null}
+          />
           <div>
             <Connect(ReduxForm)
               clearCourseReviewAlert={[Function]}
@@ -11396,6 +12057,15 @@ ShallowWrapper {
         "nodeType": "function",
         "props": Object {
           "children": Array [
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />,
             false,
             undefined,
             undefined,
@@ -11476,6 +12146,23 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "alertType": "secondary",
+              "className": "",
+              "dismissible": false,
+              "iconClassNames": Array [],
+              "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+              "onClose": [Function],
+              "title": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           false,
           undefined,
           undefined,
@@ -11565,6 +12252,7 @@ ShallowWrapper {
                 "courseSubmitInfo": Object {},
                 "currentFormValues": undefined,
                 "editCourse": [Function],
+                "editable": undefined,
                 "entitlement": Object {},
                 "fetchCourseInfo": [Function],
                 "fetchCourseOptions": [Function],
@@ -11659,6 +12347,15 @@ ShallowWrapper {
             className=""
             wide={false}
           >
+            <StatusAlert
+              alertType="secondary"
+              className=""
+              dismissible={false}
+              iconClassNames={Array []}
+              message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+              onClose={[Function]}
+              title={null}
+            />
             <div>
               <Connect(ReduxForm)
                 clearCourseReviewAlert={[Function]}
@@ -11782,6 +12479,15 @@ ShallowWrapper {
           "nodeType": "function",
           "props": Object {
             "children": Array [
+              <StatusAlert
+                alertType="secondary"
+                className=""
+                dismissible={false}
+                iconClassNames={Array []}
+                message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+                onClose={[Function]}
+                title={null}
+              />,
               false,
               undefined,
               undefined,
@@ -11862,6 +12568,23 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "alertType": "secondary",
+                "className": "",
+                "dismissible": false,
+                "iconClassNames": Array [],
+                "message": "You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator.",
+                "onClose": [Function],
+                "title": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             false,
             undefined,
             undefined,
@@ -11951,6 +12674,7 @@ ShallowWrapper {
                   "courseSubmitInfo": Object {},
                   "currentFormValues": undefined,
                   "editCourse": [Function],
+                  "editable": undefined,
                   "entitlement": Object {},
                   "fetchCourseInfo": [Function],
                   "fetchCourseOptions": [Function],

--- a/src/components/EditCoursePage/index.jsx
+++ b/src/components/EditCoursePage/index.jsx
@@ -264,6 +264,7 @@ class EditCoursePage extends React.Component {
           course_runs,
           uuid,
           owners,
+          editable,
         },
         showCreateStatusAlert,
       },
@@ -382,6 +383,11 @@ class EditCoursePage extends React.Component {
         />
 
         <PageContainer>
+          { showForm && !editable && <StatusAlert
+            alertType="secondary"
+            message="You have permission to view this course, but not edit. If you would like to edit the course, please contact your project coordinator."
+          /> }
+
           { showSpinner && <LoadingSpinner /> }
           { showReviewStatusAlert && <StatusAlert
             onClose={this.dismissAlert}
@@ -433,6 +439,7 @@ class EditCoursePage extends React.Component {
                 owners={owners}
                 isSubmittingForReview={isSubmittingForReview}
                 targetRun={targetRun}
+                editable={editable}
                 {...this.props}
               />
             </div>

--- a/src/components/ImageUpload/__snapshots__/ImageUpload.test.jsx.snap
+++ b/src/components/ImageUpload/__snapshots__/ImageUpload.test.jsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ImageUpload
     className=""
+    disabled={false}
     id="image-with-error"
     input={
       Object {
@@ -68,6 +69,7 @@ ShallowWrapper {
         />
         <input
           accept="image/jpeg, image/png"
+          disabled={false}
           id="image-with-error"
           onChange={[Function]}
           type="file"
@@ -107,6 +109,7 @@ ShallowWrapper {
           />,
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-with-error"
             onChange={[Function]}
             type="file"
@@ -169,6 +172,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "accept": "image/jpeg, image/png",
+            "disabled": false,
             "id": "image-with-error",
             "onChange": [Function],
             "type": "file",
@@ -217,6 +221,7 @@ ShallowWrapper {
           />
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-with-error"
             onChange={[Function]}
             type="file"
@@ -256,6 +261,7 @@ ShallowWrapper {
             />,
             <input
               accept="image/jpeg, image/png"
+              disabled={false}
               id="image-with-error"
               onChange={[Function]}
               type="file"
@@ -318,6 +324,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "accept": "image/jpeg, image/png",
+              "disabled": false,
               "id": "image-with-error",
               "onChange": [Function],
               "type": "file",
@@ -364,6 +371,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ImageUpload
     className=""
+    disabled={false}
     id="image-no-prior"
     input={
       Object {
@@ -418,6 +426,7 @@ ShallowWrapper {
         />
         <input
           accept="image/jpeg, image/png"
+          disabled={false}
           id="image-no-prior"
           onChange={[Function]}
           type="file"
@@ -449,6 +458,7 @@ ShallowWrapper {
           />,
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-no-prior"
             onChange={[Function]}
             type="file"
@@ -495,6 +505,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "accept": "image/jpeg, image/png",
+            "disabled": false,
             "id": "image-no-prior",
             "onChange": [Function],
             "type": "file",
@@ -534,6 +545,7 @@ ShallowWrapper {
           />
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-no-prior"
             onChange={[Function]}
             type="file"
@@ -565,6 +577,7 @@ ShallowWrapper {
             />,
             <input
               accept="image/jpeg, image/png"
+              disabled={false}
               id="image-no-prior"
               onChange={[Function]}
               type="file"
@@ -611,6 +624,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "accept": "image/jpeg, image/png",
+              "disabled": false,
               "id": "image-no-prior",
               "onChange": [Function],
               "type": "file",
@@ -657,6 +671,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ImageUpload
     className=""
+    disabled={false}
     id="image-with-prior"
     input={
       Object {
@@ -717,6 +732,7 @@ ShallowWrapper {
         />
         <input
           accept="image/jpeg, image/png"
+          disabled={false}
           id="image-with-prior"
           onChange={[Function]}
           type="file"
@@ -750,6 +766,7 @@ ShallowWrapper {
           />,
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-with-prior"
             onChange={[Function]}
             type="file"
@@ -808,6 +825,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "accept": "image/jpeg, image/png",
+            "disabled": false,
             "id": "image-with-prior",
             "onChange": [Function],
             "type": "file",
@@ -849,6 +867,7 @@ ShallowWrapper {
           />
           <input
             accept="image/jpeg, image/png"
+            disabled={false}
             id="image-with-prior"
             onChange={[Function]}
             type="file"
@@ -882,6 +901,7 @@ ShallowWrapper {
             />,
             <input
               accept="image/jpeg, image/png"
+              disabled={false}
               id="image-with-prior"
               onChange={[Function]}
               type="file"
@@ -940,6 +960,7 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "accept": "image/jpeg, image/png",
+              "disabled": false,
               "id": "image-with-prior",
               "onChange": [Function],
               "type": "file",

--- a/src/components/ImageUpload/index.jsx
+++ b/src/components/ImageUpload/index.jsx
@@ -74,6 +74,7 @@ class ImageUpload extends React.Component {
   render() {
     const {
       className,
+      disabled,
       id,
       input: {
         name,
@@ -104,7 +105,13 @@ class ImageUpload extends React.Component {
             />
           }
           <img src={this.state.value} alt="" className="uploaded-image" onLoad={this.sizeValidator} />
-          <input id={id} type="file" accept="image/jpeg, image/png" onChange={this.handleFilePicked} />
+          <input
+            id={id}
+            type="file"
+            accept="image/jpeg, image/png"
+            onChange={this.handleFilePicked}
+            disabled={disabled}
+          />
         </div>
       </div>
     );
@@ -113,6 +120,7 @@ class ImageUpload extends React.Component {
 
 ImageUpload.propTypes = {
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   maxImageSizeKilo: PropTypes.number.isRequired,
@@ -132,6 +140,7 @@ ImageUpload.propTypes = {
 
 ImageUpload.defaultProps = {
   className: '',
+  disabled: false,
 };
 
 export default ImageUpload;

--- a/src/containers/EditCourse/index.jsx
+++ b/src/containers/EditCourse/index.jsx
@@ -33,7 +33,7 @@ const mapDispatchToProps = {
 const mergeProps = (stateProps, actionProps, { id }) => ({
   ...stateProps,
   fetchCourseInfo: () => actionProps.fetchCourseInfo(id),
-  fetchCourseOptions: () => actionProps.fetchCourseOptions(id),
+  fetchCourseOptions: () => actionProps.fetchCourseOptions(),
   fetchCourseRunOptions: () => actionProps.fetchCourseRunOptions(),
   editCourse: (courseData, courseRunData, submittingRunForReview) => (
     actionProps.editCourse(courseData, courseRunData, submittingRunForReview)),

--- a/src/data/actions/courseOptions.js
+++ b/src/data/actions/courseOptions.js
@@ -4,37 +4,28 @@ import {
   REQUEST_COURSE_OPTIONS,
 } from '../constants/courseOptions';
 
-import { UUID_REGEX } from '../constants/courseInfo';
-
 import { getErrorMessages } from '../../utils';
 
 import DiscoveryDataApiService from '../services/DiscoveryDataApiService';
 
 
-function requestCourseOptionsFail(id, error) {
-  return { type: REQUEST_COURSE_OPTIONS_FAIL, id, error };
+function requestCourseOptionsFail(error) {
+  return { type: REQUEST_COURSE_OPTIONS_FAIL, error };
 }
 
-function requestCourseOptionsSuccess(id, data) {
-  return { type: REQUEST_COURSE_OPTIONS_SUCCESS, id, data };
+function requestCourseOptionsSuccess(data) {
+  return { type: REQUEST_COURSE_OPTIONS_SUCCESS, data };
 }
 
-function requestCourseOptions(id) {
-  return { type: REQUEST_COURSE_OPTIONS, id };
+function requestCourseOptions() {
+  return { type: REQUEST_COURSE_OPTIONS };
 }
 
-function fetchCourseOptions(id) {
+function fetchCourseOptions() {
   return (dispatch) => {
-    // We only support UUIDs right now, not course keys
-    if (!UUID_REGEX.test(id)) {
-      const error = `Could not get course information. ${id} is not a valid course UUID.`;
-      dispatch(requestCourseOptionsFail(id, [error]));
-      return Promise.resolve(); // early exit with empty promise
-    }
+    dispatch(requestCourseOptions());
 
-    dispatch(requestCourseOptions(id));
-
-    return DiscoveryDataApiService.fetchCourseOptions(id)
+    return DiscoveryDataApiService.fetchCourseOptions()
       .then((response) => {
         const course = response.data;
 
@@ -43,13 +34,10 @@ function fetchCourseOptions(id) {
           throw Error('Did not understand response.');
         }
 
-        dispatch(requestCourseOptionsSuccess(id, course));
+        dispatch(requestCourseOptionsSuccess(course));
       })
       .catch((error) => {
-        dispatch(requestCourseOptionsFail(
-          id,
-          ['Could not get course information.'].concat(getErrorMessages(error)),
-        ));
+        dispatch(requestCourseOptionsFail(['Could not get course information.'].concat(getErrorMessages(error))));
       });
   };
 }

--- a/src/data/actions/courseOptions.test.js
+++ b/src/data/actions/courseOptions.test.js
@@ -16,8 +16,6 @@ const mockClient = new MockAdapter(apiClient);
 apiClient.isAccessTokenExpired = jest.fn();
 apiClient.isAccessTokenExpired.mockReturnValue(false);
 
-const uuid = '11111111-1111-1111-1111-111111111111';
-
 
 describe('courseOptions fetch course actions', () => {
   afterEach(() => {
@@ -25,10 +23,10 @@ describe('courseOptions fetch course actions', () => {
   });
 
   it('handles fetch success', () => {
-    mockClient.onOptions(`http://localhost:18381/api/v1/courses/${uuid}/`)
+    mockClient.onOptions('http://localhost:18381/api/v1/courses/')
       .replyOnce(200, JSON.stringify({
         actions: {
-          PUT: {
+          POST: {
             level_type: {
               choices: [
                 { display_name: 'Beginner', value: 'beginner' },
@@ -51,10 +49,10 @@ describe('courseOptions fetch course actions', () => {
       }));
 
     const expectedActions = [
-      requestCourseOptions(uuid),
-      requestCourseOptionsSuccess(uuid, {
+      requestCourseOptions(),
+      requestCourseOptionsSuccess({
         actions: {
-          PUT: {
+          POST: {
             level_type: {
               choices: [
                 { display_name: 'Beginner', value: 'beginner' },
@@ -78,57 +76,37 @@ describe('courseOptions fetch course actions', () => {
     ];
     const store = mockStore();
 
-    return store.dispatch(fetchCourseOptions(uuid)).then(() => {
+    return store.dispatch(fetchCourseOptions()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
 
   it('handles fetch error code', () => {
-    mockClient.onOptions(`http://localhost:18381/api/v1/courses/${uuid}/`)
+    mockClient.onOptions('http://localhost:18381/api/v1/courses/')
       .replyOnce(500, '');
 
     const expectedActions = [
-      requestCourseOptions(uuid),
-      requestCourseOptionsFail(
-        uuid,
-        ['Could not get course information.', 'Request failed with status code 500.'],
-      ),
+      requestCourseOptions(),
+      requestCourseOptionsFail(['Could not get course information.', 'Request failed with status code 500.']),
     ];
     const store = mockStore();
 
-    return store.dispatch(fetchCourseOptions(uuid)).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-
-  it('handles fetch with bad id', () => {
-    const expectedActions = [
-      requestCourseOptionsFail(
-        'test',
-        ['Could not get course information. test is not a valid course UUID.'],
-      ),
-    ];
-    const store = mockStore();
-
-    return store.dispatch(fetchCourseOptions('test')).then(() => {
+    return store.dispatch(fetchCourseOptions()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });
 
   it('handles fetch with bad data', () => {
-    mockClient.onOptions(`http://localhost:18381/api/v1/courses/${uuid}/`)
+    mockClient.onOptions('http://localhost:18381/api/v1/courses/')
       .replyOnce(200, {});
 
     const expectedActions = [
-      requestCourseOptions(uuid),
-      requestCourseOptionsFail(
-        uuid,
-        ['Could not get course information.', 'Did not understand response.'],
-      ),
+      requestCourseOptions(),
+      requestCourseOptionsFail(['Could not get course information.', 'Did not understand response.']),
     ];
     const store = mockStore();
 
-    return store.dispatch(fetchCourseOptions(uuid)).then(() => {
+    return store.dispatch(fetchCourseOptions()).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/data/reducers/courseOptions.test.js
+++ b/src/data/reducers/courseOptions.test.js
@@ -12,7 +12,7 @@ describe('courseOptions reducer', () => {
 
   const courseData = {
     actions: {
-      PUT: {
+      POST: {
         level_type: {
           choices: [
             { display_name: 'Beginner', value: 'beginner' },
@@ -43,7 +43,7 @@ describe('courseOptions reducer', () => {
   });
 
   it('course options request works', () => {
-    expect(courseOptions(oldState, actions.requestCourseOptions('test')))
+    expect(courseOptions(oldState, actions.requestCourseOptions()))
       .toEqual({
         data: {},
         isFetching: true,
@@ -52,11 +52,11 @@ describe('courseOptions reducer', () => {
   });
 
   it('course options receive works', () => {
-    expect(courseOptions(oldState, actions.requestCourseOptionsSuccess('test', courseData)))
+    expect(courseOptions(oldState, actions.requestCourseOptionsSuccess(courseData)))
       .toEqual({
         data: {
           actions: {
-            PUT: {
+            POST: {
               level_type: {
                 choices: [
                   { display_name: 'Beginner', value: 'beginner' },
@@ -83,7 +83,7 @@ describe('courseOptions reducer', () => {
   });
 
   it('course options fail works', () => {
-    expect(courseOptions(oldState, actions.requestCourseOptionsFail('test', 'failure')))
+    expect(courseOptions(oldState, actions.requestCourseOptionsFail('failure')))
       .toEqual({
         data: {},
         isFetching: false,

--- a/src/data/services/DiscoveryDataApiService.js
+++ b/src/data/services/DiscoveryDataApiService.js
@@ -60,11 +60,11 @@ class DiscoveryDataApiService {
     return apiClient.post(url, data);
   }
 
-  static fetchCourseOptions(uuid) {
+  static fetchCourseOptions() {
     const queryParams = {
       editable: 1,
     };
-    const url = `${DiscoveryDataApiService.discoveryBaseUrl}/courses/${uuid}/`;
+    const url = `${DiscoveryDataApiService.discoveryBaseUrl}/courses/`;
     return apiClient.options(url, {
       params: queryParams,
     });


### PR DESCRIPTION
* Ask for OPTIONS on the list-courses endpoint, not a specific course endpoint - because the backend will refuse an OPTIONS for a specific course if you can't PUT to it.
* Support the new `editable` serialized field and disable all fields / hide buttons when it is `false` 

https://openedx.atlassian.net/browse/DISCO-1143