### PR TITLE
Disallow adding new runs when in review

### DIFF
--- a/src/components/CreateCourseRunPage/CreateCourseRunPage.test.jsx
+++ b/src/components/CreateCourseRunPage/CreateCourseRunPage.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+import { CreateCourseRunForm } from './CreateCourseRunForm';
 import CreateCourseRunPage from './index';
+import StatusAlert from '../StatusAlert';
 
 describe('CreateCourseRunPage', () => {
   it('renders html correctly', () => {
@@ -51,5 +53,31 @@ describe('CreateCourseRunPage', () => {
       }}
     />);
     expect(component).toMatchSnapshot();
+  });
+
+  it('refuses access to form when course is under review', () => {
+    const component = shallow(<CreateCourseRunPage
+      id="00000000-0000-0000-0000-000000000001"
+      courseInfo={{
+        data: {
+          course_runs: [{
+            status: 'review_by_legal',
+          }],
+          title: 'Test Course',
+        },
+        isFetching: false,
+        isCreating: false,
+        error: null,
+      }}
+    />);
+
+    // Confirm message is shown
+    const reviewAlert = component.find(StatusAlert);
+    const reviewMessage = 'Test Course has been submitted for review. No course runs can be added right now.';
+    expect(reviewAlert.props().message).toEqual(reviewMessage);
+
+    // And confirm that we don't show form
+    const form = component.find(CreateCourseRunForm);
+    expect(form).toHaveLength(0);
   });
 });

--- a/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
+++ b/src/components/CreateCourseRunPage/__snapshots__/CreateCourseRunPage.test.jsx.snap
@@ -82,6 +82,7 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             undefined,
+            undefined,
             <div>
               <ReduxForm
                 currentFormValues={Object {}}
@@ -99,6 +100,7 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          undefined,
           undefined,
           Object {
             "instance": null,
@@ -200,6 +202,7 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               undefined,
+              undefined,
               <div>
                 <ReduxForm
                   currentFormValues={Object {}}
@@ -217,6 +220,7 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            undefined,
             undefined,
             Object {
               "instance": null,
@@ -375,6 +379,7 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             undefined,
+            undefined,
             <div>
               <ReduxForm
                 currentFormValues={Object {}}
@@ -392,6 +397,7 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          undefined,
           undefined,
           Object {
             "instance": null,
@@ -493,6 +499,7 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               undefined,
+              undefined,
               <div>
                 <ReduxForm
                   currentFormValues={Object {}}
@@ -510,6 +517,7 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            undefined,
             undefined,
             Object {
               "instance": null,
@@ -685,6 +693,7 @@ ShallowWrapper {
         "props": Object {
           "children": Array [
             undefined,
+            undefined,
             <div>
               <ReduxForm
                 currentFormValues={Object {}}
@@ -717,6 +726,7 @@ ShallowWrapper {
         },
         "ref": null,
         "rendered": Array [
+          undefined,
           undefined,
           Object {
             "instance": null,
@@ -867,6 +877,7 @@ ShallowWrapper {
           "props": Object {
             "children": Array [
               undefined,
+              undefined,
               <div>
                 <ReduxForm
                   currentFormValues={Object {}}
@@ -899,6 +910,7 @@ ShallowWrapper {
           },
           "ref": null,
           "rendered": Array [
+            undefined,
             undefined,
             Object {
               "instance": null,
@@ -1085,6 +1097,7 @@ ShallowWrapper {
             <LoadingSpinner
               message="Loading…"
             />,
+            undefined,
             false,
           ],
           "className": "",
@@ -1103,6 +1116,7 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
+          undefined,
           false,
         ],
         "type": [Function],
@@ -1157,6 +1171,7 @@ ShallowWrapper {
               <LoadingSpinner
                 message="Loading…"
               />,
+              undefined,
               false,
             ],
             "className": "",
@@ -1175,6 +1190,7 @@ ShallowWrapper {
               "rendered": null,
               "type": [Function],
             },
+            undefined,
             false,
           ],
           "type": [Function],

--- a/src/components/CreateCourseRunPage/index.jsx
+++ b/src/components/CreateCourseRunPage/index.jsx
@@ -1,7 +1,9 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
+import { IN_REVIEW_STATUS } from '../../data/constants';
 import { CreateCourseRunForm } from './CreateCourseRunForm';
 import LoadingSpinner from '../LoadingSpinner';
 import StatusAlert from '../StatusAlert';
@@ -84,6 +86,11 @@ class CreateCourseRunPage extends React.Component {
   render() {
     const {
       courseInfo,
+      courseInfo: {
+        data: {
+          course_runs,
+        },
+      },
       courseRunOptions,
       formValues,
     } = this.props;
@@ -103,10 +110,12 @@ class CreateCourseRunPage extends React.Component {
       });
     }
 
-    const showSpinner = !startedFetching || courseInfo.isFetching ||
-      courseRunOptions.isFetching;
-    const showForm = startedFetching && !courseInfo.isFetching &&
-      !courseRunOptions.isFetching;
+    const courseInReview = course_runs && course_runs.some(courseRun =>
+      IN_REVIEW_STATUS.includes(courseRun.status));
+
+    const showSpinner = !startedFetching || courseInfo.isFetching || courseRunOptions.isFetching;
+    const showForm = startedFetching && !courseInfo.isFetching && !courseRunOptions.isFetching &&
+      !courseInReview;
 
     return (
       <React.Fragment>
@@ -116,6 +125,12 @@ class CreateCourseRunPage extends React.Component {
 
         <PageContainer>
           { showSpinner && <LoadingSpinner /> }
+          { courseInReview &&
+            <StatusAlert
+              alertType="warning"
+              message={`${title} has been submitted for review. No course runs can be added right now.`}
+            />
+          }
           { showForm &&
           (
             <div>


### PR DESCRIPTION
If a course is under review, don't allow the workaround of manually editing the URL field and putting in /rerun to still get the form.

Now you'll see a little warning page instead explaining that you can't add new runs.

https://openedx.atlassian.net/browse/DISCO-894

![Screenshot from 2019-07-15 12-19-43](https://user-images.githubusercontent.com/1196901/61231819-e1b0b580-a6fa-11e9-9310-c00b4e765175.png)
