### PR TITLE
Avoid submission nested error loops

### DIFF
--- a/src/components/EditCoursePage/EditCourseForm.jsx
+++ b/src/components/EditCoursePage/EditCourseForm.jsx
@@ -69,7 +69,7 @@ export class BaseEditCourseForm extends React.Component {
     const stoppingRunReview = prevProps.courseSubmitInfo.isSubmittingRunReview &&
                               !courseSubmitInfo.isSubmittingRunReview;
     const hasCourseErrors = courseSubmitInfo.errors &&
-                            courseSubmitInfo.errors !== {} &&
+                            Object.keys(courseSubmitInfo.errors).length &&
                             Object.keys(courseSubmitInfo.errors) !== ['course_runs'];
     if (stoppingRunReview && hasCourseErrors) {
       this.openCollapsible();
@@ -845,6 +845,7 @@ export class BaseEditCourseForm extends React.Component {
             collapsiblesOpen={this.state.collapsiblesOpen}
             onToggle={(index, value) => this.toggleCourseRun(index, value)}
             {...this.props}
+            validate={() => {}} // override method from our props, we don't want to pass it down
           />
           {this.getAddCourseRunButton(disabled, pristine, uuid)}
           {editable &&

--- a/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
+++ b/src/components/EditCoursePage/__snapshots__/EditCourseForm.test.jsx.snap
@@ -2925,6 +2925,7 @@ ShallowWrapper {
           title="Test Title"
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
+          validate={[Function]}
         />
         
       </form>,
@@ -5125,6 +5126,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />,
           "",
           false,
@@ -8303,6 +8305,7 @@ ShallowWrapper {
             "title": "Test Title",
             "updateFormValuesAfterSave": [Function],
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "validate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -10513,6 +10516,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />
           
         </form>,
@@ -12713,6 +12717,7 @@ ShallowWrapper {
               title="Test Title"
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
+              validate={[Function]}
             />,
             "",
             false,
@@ -15891,6 +15896,7 @@ ShallowWrapper {
               "title": "Test Title",
               "updateFormValuesAfterSave": [Function],
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "validate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -18890,6 +18896,7 @@ ShallowWrapper {
           title="Test Title"
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
+          validate={[Function]}
         />
         
       </form>,
@@ -21107,6 +21114,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />,
           "",
           false,
@@ -24302,6 +24310,7 @@ ShallowWrapper {
             "title": "Test Title",
             "updateFormValuesAfterSave": [Function],
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "validate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -26529,6 +26538,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />
           
         </form>,
@@ -28746,6 +28756,7 @@ ShallowWrapper {
               title="Test Title"
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
+              validate={[Function]}
             />,
             "",
             false,
@@ -31941,6 +31952,7 @@ ShallowWrapper {
               "title": "Test Title",
               "updateFormValuesAfterSave": [Function],
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "validate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -35081,6 +35093,7 @@ ShallowWrapper {
           title="Test Title"
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
+          validate={[Function]}
         />
         
       </form>,
@@ -37439,6 +37452,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />,
           "",
           false,
@@ -40924,6 +40938,7 @@ ShallowWrapper {
             "title": "Test Title",
             "updateFormValuesAfterSave": [Function],
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "validate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -43292,6 +43307,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />
           
         </form>,
@@ -45650,6 +45666,7 @@ ShallowWrapper {
               title="Test Title"
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
+              validate={[Function]}
             />,
             "",
             false,
@@ -49135,6 +49152,7 @@ ShallowWrapper {
               "title": "Test Title",
               "updateFormValuesAfterSave": [Function],
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "validate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -52134,6 +52152,7 @@ ShallowWrapper {
           title="Test Title"
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
+          validate={[Function]}
         />
         
       </form>,
@@ -54351,6 +54370,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />,
           "",
           false,
@@ -57546,6 +57566,7 @@ ShallowWrapper {
             "title": "Test Title",
             "updateFormValuesAfterSave": [Function],
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "validate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -59773,6 +59794,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />
           
         </form>,
@@ -61990,6 +62012,7 @@ ShallowWrapper {
               title="Test Title"
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
+              validate={[Function]}
             />,
             "",
             false,
@@ -65185,6 +65208,7 @@ ShallowWrapper {
               "title": "Test Title",
               "updateFormValuesAfterSave": [Function],
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "validate": [Function],
             },
             "ref": null,
             "rendered": null,
@@ -68077,6 +68101,7 @@ ShallowWrapper {
           title="Test Title"
           updateFormValuesAfterSave={[Function]}
           uuid="11111111-1111-1111-1111-111111111111"
+          validate={[Function]}
         />
         
       </form>,
@@ -70228,6 +70253,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />,
           "",
           false,
@@ -73332,6 +73358,7 @@ ShallowWrapper {
             "title": "Test Title",
             "updateFormValuesAfterSave": [Function],
             "uuid": "11111111-1111-1111-1111-111111111111",
+            "validate": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -75493,6 +75520,7 @@ ShallowWrapper {
             title="Test Title"
             updateFormValuesAfterSave={[Function]}
             uuid="11111111-1111-1111-1111-111111111111"
+            validate={[Function]}
           />
           
         </form>,
@@ -77644,6 +77672,7 @@ ShallowWrapper {
               title="Test Title"
               updateFormValuesAfterSave={[Function]}
               uuid="11111111-1111-1111-1111-111111111111"
+              validate={[Function]}
             />,
             "",
             false,
@@ -80748,6 +80777,7 @@ ShallowWrapper {
               "title": "Test Title",
               "updateFormValuesAfterSave": [Function],
               "uuid": "11111111-1111-1111-1111-111111111111",
+              "validate": [Function],
             },
             "ref": null,
             "rendered": null,


### PR DESCRIPTION
Stop passing down a validate method for the whole form down to the
field array of runs. This method was causing a false positive on
errors being present.